### PR TITLE
Update php_fast_cache.php

### DIFF
--- a/php_fast_cache.php
+++ b/php_fast_cache.php
@@ -203,9 +203,14 @@
                     self::$sys['method'] = "apc";
 
                 } else {
-
-
-                    $info = self::decode(file_get_contents(self::getPath()."/config.".$os['os']['unique'].".cache.ini"));
+                    
+                    $info = self::systemInfo();
+                    
+                    if (file_exists(self::getPath()."/config.".$os['os']['unique'].".cache.ini"))
+                    {
+                        $info = self::decode(file_get_contents(self::getPath()."/config.".$os['os']['unique'].".cache.ini"));
+                    }
+                    
                     $reconfig = false;
 
 


### PR DESCRIPTION
I got error for the first time running if config like this:

phpFastCache::$storage = "auto";
phpFastCache::$autosize = 50;
phpFastCache::$path = SRV_ROOT.CACHE;
phpFastCache::$securityKey = md5("cache.storage.jkdofjgh53kdod987");
phpFastCache::$server = array(
                       array("localhost",11211,30),
                       array("localhost",11211,70)
                   ); 

Warning: file_get_contents(/Applications/MAMP/htdocs/xyz/cache//e97c2fd1cbb77bf3bb5e598d1b4de426//config.D.cache.ini) [function.file-get-contents]: failed to open stream: No such file or directory in /Applications/MAMP/htdocs/xyz/mylibrary/php_fast_cache.php on line 208

File does not exists.

If on second run does not got this problem. Maybe it's a minor bug.

thanks..
