### PR TITLE
Fixed bug when using cache library in CLI mode

### DIFF
--- a/phpfastcache_v2.1_release/phpfastcache/phpfastcache.php
+++ b/phpfastcache_v2.1_release/phpfastcache/phpfastcache.php
@@ -325,7 +325,8 @@ class phpFastCache {
         $this->option("storage",$storage);
 
         if($this->option['securityKey'] == "auto" || $this->option['securityKey'] == "") {
-            $this->option['securityKey'] = "cache.storage.".$_SERVER['HTTP_HOST'];
+            $suffix = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : get_current_user();
+            $this->option['securityKey'] = "cache.storage.".$suffix;
         }
 
 


### PR DESCRIPTION
In command line mode, `$_SERVER['HTTP_HOST']` is not defined, however it's currently used to build the default security key.

In this change, I check if `HTTP_HOST` is defined and use `get_current_user()` as security key suffix otherwise. Using the current user means that different users running the same script won't share the same cache (which could be a problem with some applications).
