### PR TITLE
Added the autoload property for the mapping of the class.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,11 @@
             "homepage": "http://www.phpfastcache.com",
             "role": "Developer"
         }
-    ], 
+    ],
     "require": {
-        "php": ">=5.1.0"        
+        "php": ">=5.1.0"
+    },
+    "autoload": {
+        "files": ["phpfastcache_v2.1_release/phpfastcache/phpfastcache.php"]
     }
 }


### PR DESCRIPTION
Useful when installing via composer, because right now, you have to require the library manually, defeating the purpose of using the autoload, or tweaking the composer/installed.json file, which is kind of the same.
