### PR TITLE
$expiration instanceof \DateTimeInterface didn't work on a deployment server

### DIFF
--- a/src/phpFastCache/Cache/ItemBaseTrait.php
+++ b/src/phpFastCache/Cache/ItemBaseTrait.php
@@ -128,7 +128,7 @@ trait ItemBaseTrait
      */
     public function expiresAt($expiration)
     {
-        if ($expiration instanceof \DateTimeInterface || is_a($expiration, 'DateTime')) {
+        if ($expiration instanceof \DateTimeInterface || $expiration instanceof \DateTime) {
             $this->expirationDate = $expiration;
         } else {
             throw new \InvalidArgumentException('$expiration must be an object implementing the DateTimeInterface');

--- a/src/phpFastCache/Cache/ItemBaseTrait.php
+++ b/src/phpFastCache/Cache/ItemBaseTrait.php
@@ -128,7 +128,7 @@ trait ItemBaseTrait
      */
     public function expiresAt($expiration)
     {
-        if ($expiration instanceof \DateTimeInterface) {
+        if ($expiration instanceof \DateTimeInterface || is_a($expiration, 'DateTime')) {
             $this->expirationDate = $expiration;
         } else {
             throw new \InvalidArgumentException('$expiration must be an object implementing the DateTimeInterface');


### PR DESCRIPTION
This wee change fixes it. Everything still works as far as I've tested.

stack trace I received before my fix:
``Fatal error: Uncaught exception 'InvalidArgumentException' with message '$expiration must be an object implementing the DateTimeInterface' in /var/www/vhosts/rkpsc.com/httpdocs/wp-content/plugins/knvb/vendor/phpfastcache/phpfastcache/src/phpFastCache/Cache/ItemBaseTrait.php:134 Stack trace: #0 /var/www/vhosts/rkpsc.com/httpdocs/wp-content/plugins/knvb/vendor/phpfastcache/phpfastcache/src/phpFastCache/Core/StandardPsr6StructureTrait.php(59): phpFastCache\Drivers\Files\Item->expiresAt(Object(DateTime)) #1 /var/www/vhosts/rkpsc.com/httpdocs/wp-content/plugins/knvb/components/wp-admin/short-codes.php(46): phpFastCache\Core\DriverAbstract->getItem('team-rank_{"nam...') #2 [internal function]: knvb(Array, '', 'knvb') #3 /var/www/vhosts/rkpsc.com/httpdocs/wp-includes/shortcodes.php(326): call_user_func('knvb', Array, '', 'knvb') #4 [internal function]: do_shortcode_tag(Array) #5 /var/www/vhosts/rkpsc.com/httpdocs/wp-includes/shortcodes.php(223): preg_replace_callback('/\[(\[?)(knvb)(...', 'do_shortcode_ta...', '<div class="ran.. in /var/www/vhosts/rkpsc.com/httpdocs/wp-content/plugins/knvb/vendor/phpfastcache/phpfastcache/src/phpFastCache/Cache/ItemBaseTrait.php on line 134``

eventho it was a datetime instance