### PR TITLE
Multiples fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ script:
   - php -f tests/Autoload.test.php
   - php -f tests/NewCacheInstance.test.php
   - php -f tests/Psr6InterfaceImplements.test.php
+  - php -f tests/AbstractProxy.test.php

--- a/src/phpFastCache/Cache/DriverBaseTrait.php
+++ b/src/phpFastCache/Cache/DriverBaseTrait.php
@@ -281,7 +281,7 @@ trait DriverBaseTrait
                 $this->driverWrite($tagsItem);
                 $tagsItem->setHit(true);
             } else {
-                $this->driverDelete($tagsItem);
+                $this->deleteItem($tagsItem);
             }
         }
 

--- a/src/phpFastCache/Core/StandardPsr6StructureTrait.php
+++ b/src/phpFastCache/Core/StandardPsr6StructureTrait.php
@@ -63,8 +63,11 @@ trait StandardPsr6StructureTrait
                          * Using driverDelete() instead of delete()
                          * to avoid infinite loop caused by
                          * getItem() call in delete() method
+                         * As we MUST return an item in any
+                         * way, we do not de-register here
                          */
                         $this->driverDelete($item);
+
                     } else {
                         $item->setHit(true);
                     }
@@ -145,7 +148,11 @@ trait StandardPsr6StructureTrait
         if ($this->hasItem($key) && $this->driverDelete($item)) {
             $item->setHit(false);
             CacheManager::$WriteHits++;
-            unset($this->itemInstances[ $key ]);
+            /**
+             * De-register the item instance
+             * then collect gc cycles
+             */
+            $this->deregisterItem($key);
 
             return true;
         }

--- a/src/phpFastCache/Drivers/Files/Driver.php
+++ b/src/phpFastCache/Drivers/Files/Driver.php
@@ -117,15 +117,8 @@ class Driver extends DriverAbstract
         }
 
         $content = $this->readfile($file_path);
-        $object = $this->decode($content);
 
-        if ($this->driverUnwrapTime($object)->getTimestamp() < time()) {
-            @unlink($file_path);
-
-            return null;
-        }
-
-        return $object;
+        return $this->decode($content);
 
     }
 

--- a/src/phpFastCache/Drivers/Sqlite/Driver.php
+++ b/src/phpFastCache/Drivers/Sqlite/Driver.php
@@ -329,17 +329,7 @@ class Driver extends DriverAbstract
             }
         }
 
-        if (isset($row[ 'id' ])) {
-            /**
-             * @var $item ExtendedCacheItemInterface
-             */
-            $item = $this->decode($row[ 'object' ]);
-            if ($item instanceof ExtendedCacheItemInterface && $item->isExpired()) {
-                $this->driverDelete($item);
-
-                return null;
-            }
-
+        if (isset($row[ 'object' ])) {
             return $this->decode($row[ 'object' ]);
         }
 

--- a/tests/AbstractProxy.test.php
+++ b/tests/AbstractProxy.test.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @author Khoa Bui (khoaofgod)  <khoaofgod@gmail.com> http://www.phpfastcache.com
+ * @author Georges.L (Geolim4)  <contact@geolim4.com>
+ */
+
+use phpFastCache\Core\Item\ExtendedCacheItemInterface;
+use phpFastCache\Drivers\Memcached\Driver as MemcachedDriver;
+use phpFastCache\Proxy\phpFastCacheAbstractProxy;
+
+
+chdir(__DIR__);
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$status = 0;
+echo "Testing phpFastCacheAbstractProxy class\n";
+
+/**
+ * Dynamic driver-based example
+ * Class myCustomCacheClass
+ * @package MyCustom\Project
+ */
+class CustomMemcachedCacheClass extends phpFastCacheAbstractProxy
+{
+    public function __construct($driver = '', array $config = [])
+    {
+        $driver = 'Memcached';
+        parent::__construct($driver, $config);
+        /**
+         * That's all !! Your cache class is ready to use
+         */
+    }
+}
+
+
+/**
+ * Testing memcached as it is declared in .travis.yml
+ */
+$driverInstance = new CustomMemcachedCacheClass();
+
+if (!is_object($driverInstance->getItem('test'))) {
+    echo '[FAIL] $driverInstance->getItem() returned an invalid var type:' . gettype($driverInstance) . "\n";
+    $status = 1;
+}else if(!($driverInstance->getItem('test') instanceof ExtendedCacheItemInterface)){
+    echo '[FAIL] $driverInstance->getItem() returned an invalid class that does not implements ExtendedCacheItemInterface: ' . get_class($driverInstance) . "\n";
+    $status = 1;
+}else{
+    echo '[PASS] $driverInstance->getItem() returned a valid class that implements ExtendedCacheItemInterface: ' . get_class($driverInstance) . "\n";
+}
+
+exit($status);

--- a/tests/AbstractProxy.test.php
+++ b/tests/AbstractProxy.test.php
@@ -5,8 +5,7 @@
  * @author Georges.L (Geolim4)  <contact@geolim4.com>
  */
 
-use phpFastCache\Core\Item\ExtendedCacheItemInterface;
-use phpFastCache\Drivers\Memcached\Driver as MemcachedDriver;
+use phpFastCache\Cache\ExtendedCacheItemInterface;
 use phpFastCache\Proxy\phpFastCacheAbstractProxy;
 
 


### PR DESCRIPTION
- Removed unused datetime check on file-based drivers. They are already handled by the getItem() method
- Fixed bug with tags that leave residues key to tags item themselves