### PR TITLE
Create MongoDb new Driver using MondoDb/Driver with mongo-php-library and rename MongoDb legacy driver to Mongo Driver.

### DIFF
--- a/src/phpFastCache/CacheManager.php
+++ b/src/phpFastCache/CacheManager.php
@@ -30,6 +30,7 @@ use phpFastCache\Exceptions\phpFastCacheDriverCheckException;
  * @method static ExtendedCacheItemPoolInterface Leveldb() Leveldb($config = []) Return a driver "leveldb" instance
  * @method static ExtendedCacheItemPoolInterface Memcache() Memcache($config = []) Return a driver "memcache" instance
  * @method static ExtendedCacheItemPoolInterface Memcached() Memcached($config = []) Return a driver "memcached" instance
+ * @method static ExtendedCacheItemPoolInterface Mongo() Mongo($config = []) Return a driver "mongo" instance
  * @method static ExtendedCacheItemPoolInterface Mongodb() Mongodb($config = []) Return a driver "mongodb" instance
  * @method static ExtendedCacheItemPoolInterface Predis() Predis($config = []) Return a driver "predis" instance
  * @method static ExtendedCacheItemPoolInterface Redis() Redis($config = []) Return a driver "redis" instance
@@ -228,6 +229,7 @@ class CacheManager
           'Memcache',
           'Memcached',
           'Couchbase',
+		  'Mongo',
           'Mongodb',
           'Predis',
           'Redis',

--- a/src/phpFastCache/Drivers/Mongo/Item.php
+++ b/src/phpFastCache/Drivers/Mongo/Item.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ *
+ * This file is part of phpFastCache.
+ *
+ * @license MIT License (MIT)
+ *
+ * For full copyright and license information, please see the docs/CREDITS.txt file.
+ *
+ * @author Khoa Bui (khoaofgod)  <khoaofgod@gmail.com> http://www.phpfastcache.com
+ * @author Georges.L (Geolim4)  <contact@geolim4.com>
+ *
+ */
+
+namespace phpFastCache\Drivers\Mongo;
+
+use phpFastCache\Cache\ExtendedCacheItemInterface;
+use phpFastCache\Cache\ExtendedCacheItemPoolInterface;
+use phpFastCache\Cache\ItemBaseTrait;
+use phpFastCache\Drivers\Mongodb\Driver as MongodbDriver;
+
+/**
+ * Class Item
+ * @package phpFastCache\Drivers\Apc
+ */
+class Item implements ExtendedCacheItemInterface
+{
+    use ItemBaseTrait;
+
+    /**
+     * Item constructor.
+     * @param \phpFastCache\Drivers\Mongodb\Driver $driver
+     * @param $key
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(MongodbDriver $driver, $key)
+    {
+        if (is_string($key)) {
+            $this->key = $key;
+            $this->driver = $driver;
+            $this->driver->setItem($this);
+            $this->expirationDate = new \DateTime();
+        } else {
+            throw new \InvalidArgumentException(sprintf('$key must be a string, got type "%s" instead.', gettype($key)));
+        }
+    }
+
+    /**
+     * @param ExtendedCacheItemPoolInterface $driver
+     * @throws \InvalidArgumentException
+     * @return static
+     */
+    public function setDriver(ExtendedCacheItemPoolInterface $driver)
+    {
+        if ($driver instanceof MongodbDriver) {
+            $this->driver = $driver;
+
+            return $this;
+        } else {
+            throw new \InvalidArgumentException('Invalid driver instance');
+        }
+    }
+}

--- a/src/phpFastCache/Drivers/Mongo/Item.php
+++ b/src/phpFastCache/Drivers/Mongo/Item.php
@@ -17,7 +17,7 @@ namespace phpFastCache\Drivers\Mongo;
 use phpFastCache\Cache\ExtendedCacheItemInterface;
 use phpFastCache\Cache\ExtendedCacheItemPoolInterface;
 use phpFastCache\Cache\ItemBaseTrait;
-use phpFastCache\Drivers\Mongodb\Driver as MongodbDriver;
+use phpFastCache\Drivers\Mongo\Driver as MongoDriver;
 
 /**
  * Class Item
@@ -29,11 +29,11 @@ class Item implements ExtendedCacheItemInterface
 
     /**
      * Item constructor.
-     * @param \phpFastCache\Drivers\Mongodb\Driver $driver
+     * @param \phpFastCache\Drivers\Mongo\Driver $driver
      * @param $key
      * @throws \InvalidArgumentException
      */
-    public function __construct(MongodbDriver $driver, $key)
+    public function __construct(MongoDriver $driver, $key)
     {
         if (is_string($key)) {
             $this->key = $key;
@@ -52,7 +52,7 @@ class Item implements ExtendedCacheItemInterface
      */
     public function setDriver(ExtendedCacheItemPoolInterface $driver)
     {
-        if ($driver instanceof MongodbDriver) {
+        if ($driver instanceof MongoDriver) {
             $this->driver = $driver;
 
             return $this;

--- a/src/phpFastCache/Drivers/Mongodb/Driver.php
+++ b/src/phpFastCache/Drivers/Mongodb/Driver.php
@@ -9,6 +9,7 @@
  *
  * @author Khoa Bui (khoaofgod)  <khoaofgod@gmail.com> http://www.phpfastcache.com
  * @author Georges.L (Geolim4)  <contact@geolim4.com>
+ * @author Fabio Covolo Mazzo (fabiocmazzo) <fabiomazzo@gmail.com>
  *
  */
 

--- a/src/phpFastCache/Drivers/Mongodb/Item.php
+++ b/src/phpFastCache/Drivers/Mongodb/Item.php
@@ -9,6 +9,7 @@
  *
  * @author Khoa Bui (khoaofgod)  <khoaofgod@gmail.com> http://www.phpfastcache.com
  * @author Georges.L (Geolim4)  <contact@geolim4.com>
+ * @author Fabio Covolo Mazzo (fabiocmazzo) <fabiomazzo@gmail.com>
  *
  */
 


### PR DESCRIPTION
Hi,
  I needed to implement a driver for the new MongoDb PHP Driver and would like to share back this improvement. I kept the legacy driver and renamed to Mongo, the new was as Mongodb.

I hope that helps 1% of what you helped me sharing PhpFastCache.

Thank you