### PR TITLE
Add Drivers for Zend Data Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,17 @@ One Class uses for All Cache. You don't need to rewrite your code many times aga
 
 ### Supported drivers at this day *
 
-| Regular drivers  | High performances drivers | Development driver |
-|------------------|---------------------------|--------------------|
-|  `Apc(u)`        | `CouchBase`               | `Devnull`          |
-|  `Cookie`        | `Mongodb`                 | `Devfalse`         |
-|  `Files`         | `Predis`                  | `Devtrue`          |
-|  `Leveldb`       | `Redis`                   |                    |
-|  `Memcache(d)`   | `Ssdb`                    |                    |
-|  `Sqlite`        |                           |                    |
-|  `Wincache`      |                           |                    |
-|  `Xcache`        |                           |                    |
+|   Regular drivers  | High performances drivers | Development driver |
+|--------------------|---------------------------|--------------------|
+|  `Apc(u)`          | `CouchBase`               | `Devnull`          |
+|  `Cookie`          | `Mongodb`                 | `Devfalse`         |
+|  `Files`           | `Predis`                  | `Devtrue`          |
+|  `Leveldb`         | `Redis`                   |                    |
+|  `Memcache(d)`     | `Ssdb`                    |                    |
+|  `Sqlite`          | `Zend Memory Cache`       |                    |
+|  `Wincache`        |                           |                    |
+|  `Xcache`          |                           |                    |
+|  `Zend Disk Cache` |                           |                    |
 
 \* Driver descriptions available in DOCS/DRIVERS.md
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "phpfastcache/phpfastcache",
     "type" : "library",
-    "description": "PHP Cache Class - Reduce your database call using cache system. PhpFastCache handles a lot of drivers such as Apc(u), CouchBase, Mongodb, Files, (P)redis, Leveldb, Memcache(d), Ssdb, Sqlite, Wincache, Xcache.",
-    "keywords": ["cache","caching","php cache","mysql cache","apc","apcu","memcache","memcached","wincache","files cache","pdo cache","cache class","redis","predis","cookie", "mongodb", "couchbase", "LevelDb", "Ssdb", "Wincache", "xcache"],
+    "description": "PHP Cache Class - Reduce your database call using cache system. PhpFastCache handles a lot of drivers such as Apc(u), CouchBase, Mongodb, Files, (P)redis, Leveldb, Memcache(d), Ssdb, Sqlite, Wincache, Xcache, Zend Data Cache.",
+    "keywords": ["cache","caching","php cache","mysql cache","apc","apcu","memcache","memcached","wincache","files cache","pdo cache","cache class","redis","predis","cookie", "mongodb", "couchbase", "LevelDb", "Ssdb", "Wincache", "xcache","zend","zend disk cache","zend memory cache","zend data cache","zend server"],
     "homepage": "http://www.phpfastcache.com",
     "license": "MIT",
     "authors": [

--- a/docs/DRIVERS.md
+++ b/docs/DRIVERS.md
@@ -35,7 +35,7 @@
   * The Wincache driver. A memory cache for regular performances on Windows platforms.
 * Xcache
   * The Xcache driver. A memory cache for regular performances.
-* Zend Disk Cache
+* Zend Disk Cache ( * Requires ZendServer Version 4 or higher * )
   * The Zend Data Cache is a by ZendServer supported file cache. The cache is for regular performance.
-* Zend Memory Cache
+* Zend Memory Cache ( * Requires ZendServer Version 4 or higher * )
   * The Zend Memory Cache is a by ZendServer supported memory cache. The cache is for high-performance applications.

--- a/docs/DRIVERS.md
+++ b/docs/DRIVERS.md
@@ -35,3 +35,7 @@
   * The Wincache driver. A memory cache for regular performances on Windows platforms.
 * Xcache
   * The Xcache driver. A memory cache for regular performances.
+* Zend Disk Cache
+  * The Zend Data Cache is a by ZendServer supported file cache. The cache is for regular performance.
+* Zend Disk Cache
+  * The Zend Memory Cache is a by ZendServer supported memory cache. The cache is for high-performance applications.

--- a/docs/DRIVERS.md
+++ b/docs/DRIVERS.md
@@ -37,5 +37,5 @@
   * The Xcache driver. A memory cache for regular performances.
 * Zend Disk Cache
   * The Zend Data Cache is a by ZendServer supported file cache. The cache is for regular performance.
-* Zend Disk Cache
+* Zend Memory Cache
   * The Zend Memory Cache is a by ZendServer supported memory cache. The cache is for high-performance applications.

--- a/examples/zend_disk.php
+++ b/examples/zend_disk.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ *
+ * This file is part of phpFastCache.
+ *
+ * @license MIT License (MIT)
+ *
+ * For full copyright and license information, please see the docs/CREDITS.txt file.
+ *
+ * @author Lucas Brucksch <support@hammermaps.de>
+ *
+ */
+// Include composer autoloader
+require __DIR__ . '/../vendor/autoload.php';
+// OR require_once("../src/phpFastCache/phpFastCache.php");
+date_default_timezone_set("Europe/Paris");
+
+
+use phpFastCache\CacheManager;
+use phpFastCache\Core\phpFastCache;
+
+// In your class, function, you can call the Cache
+$InstanceCache = CacheManager::getInstance('zenddisk');
+// OR $InstanceCache = CacheManager::getInstance() <-- open examples/global.setup.php to see more
+
+/**
+ * Try to get $products from Caching First
+ * product_page is "identity keyword";
+ */
+$key = "product_page";
+$CachedString = $InstanceCache->getItem($key);
+
+if (is_null($CachedString->get())) {
+    //$CachedString = "Zend Disk Cache --> Cache Enabled --> Well done !";
+    // Write products to Cache in 10 minutes with same keyword
+    $CachedString->set("Zend Disk Cache --> Cache Enabled --> Well done !");
+    $InstanceCache->save($CachedString);
+
+    echo "FIRST LOAD // WROTE OBJECT TO CACHE // RELOAD THE PAGE AND SEE // ";
+    echo $CachedString->get();
+
+} else {
+    echo "READ FROM CACHE // ";
+    echo $CachedString->getExpirationDate()->format(Datetime::W3C);
+    echo $CachedString->get();
+}
+
+echo '<br /><br /><a href="/">Back to index</a>&nbsp;--&nbsp;<a href="./' . basename(__FILE__) . '">Reload</a>';

--- a/examples/zend_shm.php
+++ b/examples/zend_shm.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ *
+ * This file is part of phpFastCache.
+ *
+ * @license MIT License (MIT)
+ *
+ * For full copyright and license information, please see the docs/CREDITS.txt file.
+ *
+ * @author Lucas Brucksch <support@hammermaps.de>
+ *
+ */
+use phpFastCache\CacheManager;
+
+// Include composer autoloader
+require __DIR__ . '/../vendor/autoload.php';
+
+$InstanceCache = CacheManager::getInstance('zendshm');
+
+/**
+ * Try to get $products from Caching First
+ * product_page is "identity keyword";
+ */
+$key = "product_page";
+$CachedString = $InstanceCache->getItem($key);
+
+if (is_null($CachedString->get())) {
+    //$CachedString = "Zend Memory Cache --> Cache Enabled --> Well done !";
+    // Write products to Cache in 10 minutes with same keyword
+    $CachedString->set("Zend Memory Cache --> Cache Enabled --> Well done !")->expiresAfter(5);
+    $InstanceCache->save($CachedString);
+
+    echo "FIRST LOAD // WROTE OBJECT TO CACHE // RELOAD THE PAGE AND SEE // ";
+    echo $CachedString->get();
+
+} else {
+    echo "READ FROM CACHE // ";
+    echo $CachedString->get();
+}
+
+echo '<br /><br /><a href="/">Back to index</a>&nbsp;--&nbsp;<a href="./' . basename(__FILE__) . '">Reload</a>';

--- a/src/phpFastCache/CacheManager.php
+++ b/src/phpFastCache/CacheManager.php
@@ -237,6 +237,8 @@ class CacheManager
           'Leveldb',
           'Wincache',
           'Xcache',
+          'Zenddisk',
+          'Zendshm',
           'Devnull',
         ];
     }

--- a/src/phpFastCache/CacheManager.php
+++ b/src/phpFastCache/CacheManager.php
@@ -37,6 +37,8 @@ use phpFastCache\Exceptions\phpFastCacheDriverCheckException;
  * @method static ExtendedCacheItemPoolInterface Ssdb() Ssdb($config = []) Return a driver "ssdb" instance
  * @method static ExtendedCacheItemPoolInterface Wincache() Wincache($config = []) Return a driver "wincache" instance
  * @method static ExtendedCacheItemPoolInterface Xcache() Xcache($config = []) Return a driver "xcache" instance
+ * @method static ExtendedCacheItemPoolInterface Zenddisk() Zenddisk($config = []) Return a driver "zend disk cache" instance
+ * @method static ExtendedCacheItemPoolInterface Zendshm() Zendshm($config = []) Return a driver "zend memory cache" instance
  *
  */
 class CacheManager

--- a/src/phpFastCache/Drivers/Zenddisk/Driver.php
+++ b/src/phpFastCache/Drivers/Zenddisk/Driver.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ *
+ * This file is part of phpFastCache.
+ *
+ * @license MIT License (MIT)
+ *
+ * For full copyright and license information, please see the docs/CREDITS.txt file.
+ *
+ * @author Lucas Brucksch <support@hammermaps.de>
+ *
+ */
+
+namespace phpFastCache\Drivers\Zenddisk;
+
+use phpFastCache\Core\DriverAbstract;
+use phpFastCache\Core\StandardPsr6StructureTrait;
+use phpFastCache\Entities\driverStatistic;
+use phpFastCache\Exceptions\phpFastCacheDriverCheckException;
+use phpFastCache\Exceptions\phpFastCacheDriverException;
+use Psr\Cache\CacheItemInterface;
+
+/**
+ * Class Driver (zend disk cache)
+ * Requires Zend Data Cache Functions from ZendServer
+ * @package phpFastCache\Drivers
+ */
+class Driver extends DriverAbstract
+{
+    /**
+     * Driver constructor.
+     * @param array $config
+     * @throws phpFastCacheDriverException
+     */
+    public function __construct(array $config = [])
+    {
+        $this->setup($config);
+
+        if (!$this->driverCheck()) {
+            throw new phpFastCacheDriverCheckException(sprintf(self::DRIVER_CHECK_FAILURE, $this->getDriverName()));
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function driverCheck()
+    {
+        if (extension_loaded('Zend Data Cache') && function_exists('zend_disk_cache_store')) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @param \Psr\Cache\CacheItemInterface $item
+     * @return mixed
+     * @throws \InvalidArgumentException
+     */
+    protected function driverWrite(CacheItemInterface $item)
+    {
+        /**
+         * Check for Cross-Driver type confusion
+         */
+        if ($item instanceof Item) {
+            $ttl = $item->getExpirationDate()->getTimestamp() - time();
+
+            return zend_disk_cache_store($item->getKey(), $this->driverPreWrap($item), ($ttl > 0 ? $ttl : 0));
+        } else {
+            throw new \InvalidArgumentException('Cross-Driver type confusion detected');
+        }
+    }
+
+    /**
+     * @param \Psr\Cache\CacheItemInterface $item
+     * @return mixed
+     */
+    protected function driverRead(CacheItemInterface $item)
+    {
+        $data = zend_disk_cache_fetch($item->getKey());
+        if ($data === false) {
+            return null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param \Psr\Cache\CacheItemInterface $item
+     * @return bool
+     * @throws \InvalidArgumentException
+     */
+    protected function driverDelete(CacheItemInterface $item)
+    {
+        /**
+         * Check for Cross-Driver type confusion
+         */
+        if ($item instanceof Item) {
+            return zend_disk_cache_delete($item->getKey());
+        } else {
+            throw new \InvalidArgumentException('Cross-Driver type confusion detected');
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    protected function driverClear()
+    {
+        return @zend_disk_cache_clear();
+    }
+
+    /**
+     * @return bool
+     */
+    protected function driverConnect()
+    {
+        return true;
+    }
+
+    /********************
+     *
+     * PSR-6 Extended Methods
+     *
+     *******************/
+
+    /**
+     * @return driverStatistic
+     */
+    public function getStats()
+    {
+        $stat = new driverStatistic();
+        $stat->setInfo('[ZendDisk] A void info string')
+            ->setSize(0)
+            ->setData(implode(', ', array_keys($this->itemInstances)))
+            ->setRawData(false);
+
+        return $stat;
+    }
+}

--- a/src/phpFastCache/Drivers/Zenddisk/Item.php
+++ b/src/phpFastCache/Drivers/Zenddisk/Item.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ *
+ * This file is part of phpFastCache.
+ *
+ * @license MIT License (MIT)
+ *
+ * For full copyright and license information, please see the docs/CREDITS.txt file.
+ *
+ * @author Lucas Brucksch <support@hammermaps.de>
+ *
+ */
+
+namespace phpFastCache\Drivers\Zenddisk;
+
+use phpFastCache\Cache\ExtendedCacheItemInterface;
+use phpFastCache\Cache\ExtendedCacheItemPoolInterface;
+use phpFastCache\Cache\ItemBaseTrait;
+use phpFastCache\Drivers\Zenddisk\Driver as ZendDiskDriver;
+
+/**
+ * Class Item
+ * @package phpFastCache\Drivers\Zenddisk
+ */
+class Item implements ExtendedCacheItemInterface
+{
+    use ItemBaseTrait;
+
+    /**
+     * Item constructor.
+     * @param \phpFastCache\Drivers\Zenddisk\Driver $driver
+     * @param $key
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(ZendDiskDriver $driver, $key)
+    {
+        if (is_string($key)) {
+            $this->key = $key;
+            $this->driver = $driver;
+            $this->driver->setItem($this);
+            $this->expirationDate = new \DateTime();
+        } else {
+            throw new \InvalidArgumentException(sprintf('$key must be a string, got type "%s" instead.', gettype($key)));
+        }
+    }
+
+    /**
+     * @param ExtendedCacheItemPoolInterface $driver
+     * @throws \InvalidArgumentException
+     * @return static
+     */
+    public function setDriver(ExtendedCacheItemPoolInterface $driver)
+    {
+        if ($driver instanceof ZendDiskDriver) {
+            $this->driver = $driver;
+
+            return $this;
+        } else {
+            throw new \InvalidArgumentException('Invalid driver instance');
+        }
+    }
+}

--- a/src/phpFastCache/Drivers/Zendshm/Driver.php
+++ b/src/phpFastCache/Drivers/Zendshm/Driver.php
@@ -130,11 +130,20 @@ class Driver extends DriverAbstract
      */
     public function getStats()
     {
-        $stats = (array) zend_shm_cache_info();
-        return (new driverStatistic())
-            ->setData(implode(', ', array_keys($this->namespaces)))
-            ->setInfo(sprintf("The Zend memory have %d item(s) in cache.\n For more information see RawData.",$stats[ 'items_total' ]))
-            ->setRawData($stats)
-            ->setSize($stats[ 'memory_total' ]);
+        if(function_exists('zend_shm_cache_info')) {
+            $stats = (array)zend_shm_cache_info();
+            return (new driverStatistic())
+                ->setData(implode(', ', array_keys($this->namespaces)))
+                ->setInfo(sprintf("The Zend memory have %d item(s) in cache.\n For more information see RawData.", $stats['items_total']))
+                ->setRawData($stats)
+                ->setSize($stats['memory_total']);
+        } else {
+            /** zend_shm_cache_info supported V8 or higher */
+            return (new driverStatistic())
+                ->setData(implode(', ', array_keys($this->namespaces)))
+                ->setInfo("The Zend memory statistics is only supported by ZendServer V8 or higher")
+                ->setRawData(null)
+                ->setSize(0);
+        }
     }
 }

--- a/src/phpFastCache/Drivers/Zendshm/Driver.php
+++ b/src/phpFastCache/Drivers/Zendshm/Driver.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ *
+ * This file is part of phpFastCache.
+ *
+ * @license MIT License (MIT)
+ *
+ * For full copyright and license information, please see the docs/CREDITS.txt file.
+ *
+ * @author Lucas Brucksch <support@hammermaps.de>
+ *
+ */
+
+namespace phpFastCache\Drivers\Zendshm;
+
+use phpFastCache\Core\DriverAbstract;
+use phpFastCache\Core\StandardPsr6StructureTrait;
+use phpFastCache\Entities\driverStatistic;
+use phpFastCache\Exceptions\phpFastCacheDriverCheckException;
+use phpFastCache\Exceptions\phpFastCacheDriverException;
+use Psr\Cache\CacheItemInterface;
+
+/**
+ * Class Driver (zend memory cache)
+ * Requires Zend Data Cache Functions from ZendServer
+ * @package phpFastCache\Drivers
+ */
+class Driver extends DriverAbstract
+{
+    /**
+     * Driver constructor.
+     * @param array $config
+     * @throws phpFastCacheDriverException
+     */
+    public function __construct(array $config = [])
+    {
+        $this->setup($config);
+
+        if (!$this->driverCheck()) {
+            throw new phpFastCacheDriverCheckException(sprintf(self::DRIVER_CHECK_FAILURE, $this->getDriverName()));
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function driverCheck()
+    {
+        if (extension_loaded('Zend Data Cache') && function_exists('zend_shm_cache_store')) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @param \Psr\Cache\CacheItemInterface $item
+     * @return mixed
+     * @throws \InvalidArgumentException
+     */
+    protected function driverWrite(CacheItemInterface $item)
+    {
+        /**
+         * Check for Cross-Driver type confusion
+         */
+        if ($item instanceof Item) {
+            $ttl = $item->getExpirationDate()->getTimestamp() - time();
+
+            return zend_shm_cache_store($item->getKey(), $this->driverPreWrap($item), ($ttl > 0 ? $ttl : 0));
+        } else {
+            throw new \InvalidArgumentException('Cross-Driver type confusion detected');
+        }
+    }
+
+    /**
+     * @param \Psr\Cache\CacheItemInterface $item
+     * @return mixed
+     */
+    protected function driverRead(CacheItemInterface $item)
+    {
+        $data = zend_shm_cache_fetch($item->getKey());
+        if ($data === false) {
+            return null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param \Psr\Cache\CacheItemInterface $item
+     * @return bool
+     * @throws \InvalidArgumentException
+     */
+    protected function driverDelete(CacheItemInterface $item)
+    {
+        /**
+         * Check for Cross-Driver type confusion
+         */
+        if ($item instanceof Item) {
+            return zend_shm_cache_delete($item->getKey());
+        } else {
+            throw new \InvalidArgumentException('Cross-Driver type confusion detected');
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    protected function driverClear()
+    {
+        return @zend_shm_cache_clear();
+    }
+
+    /**
+     * @return bool
+     */
+    protected function driverConnect()
+    {
+        return true;
+    }
+
+    /********************
+     *
+     * PSR-6 Extended Methods
+     *
+     *******************/
+
+    /**
+     * @return driverStatistic
+     */
+    public function getStats()
+    {
+        $stats = (array) zend_shm_cache_info();
+        return (new driverStatistic())
+            ->setData(implode(', ', array_keys($this->namespaces)))
+            ->setInfo(sprintf("The Zend memory have %d item(s) in cache.\n For more information see RawData.",$stats[ 'items_total' ]))
+            ->setRawData($stats)
+            ->setSize($stats[ 'memory_total' ]);
+    }
+}

--- a/src/phpFastCache/Drivers/Zendshm/Driver.php
+++ b/src/phpFastCache/Drivers/Zendshm/Driver.php
@@ -133,14 +133,14 @@ class Driver extends DriverAbstract
         if(function_exists('zend_shm_cache_info')) {
             $stats = (array)zend_shm_cache_info();
             return (new driverStatistic())
-                ->setData(implode(', ', array_keys($this->namespaces)))
+                ->setData(implode(', ', array_keys($this->itemInstances)))
                 ->setInfo(sprintf("The Zend memory have %d item(s) in cache.\n For more information see RawData.", $stats['items_total']))
                 ->setRawData($stats)
                 ->setSize($stats['memory_total']);
         } else {
             /** zend_shm_cache_info supported V8 or higher */
             return (new driverStatistic())
-                ->setData(implode(', ', array_keys($this->namespaces)))
+                ->setData(implode(', ', array_keys($this->itemInstances)))
                 ->setInfo("The Zend memory statistics is only supported by ZendServer V8 or higher")
                 ->setRawData(null)
                 ->setSize(0);

--- a/src/phpFastCache/Drivers/Zendshm/Item.php
+++ b/src/phpFastCache/Drivers/Zendshm/Item.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ *
+ * This file is part of phpFastCache.
+ *
+ * @license MIT License (MIT)
+ *
+ * For full copyright and license information, please see the docs/CREDITS.txt file.
+ *
+ * @author Lucas Brucksch <support@hammermaps.de>
+ *
+ */
+
+namespace phpFastCache\Drivers\Zendhm;
+
+use phpFastCache\Cache\ExtendedCacheItemInterface;
+use phpFastCache\Cache\ExtendedCacheItemPoolInterface;
+use phpFastCache\Cache\ItemBaseTrait;
+use phpFastCache\Drivers\Zendshm\Driver as ZendSHMDriver;
+
+/**
+ * Class Item
+ * @package phpFastCache\Drivers\Zendshm
+ */
+class Item implements ExtendedCacheItemInterface
+{
+    use ItemBaseTrait;
+
+    /**
+     * Item constructor.
+     * @param \phpFastCache\Drivers\Zendshm\Driver $driver
+     * @param $key
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(ZendSHMDriver $driver, $key)
+    {
+        if (is_string($key)) {
+            $this->key = $key;
+            $this->driver = $driver;
+            $this->driver->setItem($this);
+            $this->expirationDate = new \DateTime();
+        } else {
+            throw new \InvalidArgumentException(sprintf('$key must be a string, got type "%s" instead.', gettype($key)));
+        }
+    }
+
+    /**
+     * @param ExtendedCacheItemPoolInterface $driver
+     * @throws \InvalidArgumentException
+     * @return static
+     */
+    public function setDriver(ExtendedCacheItemPoolInterface $driver)
+    {
+        if ($driver instanceof ZendSHMDriver) {
+            $this->driver = $driver;
+
+            return $this;
+        } else {
+            throw new \InvalidArgumentException('Invalid driver instance');
+        }
+    }
+}

--- a/src/phpFastCache/Drivers/Zendshm/Item.php
+++ b/src/phpFastCache/Drivers/Zendshm/Item.php
@@ -11,7 +11,7 @@
  *
  */
 
-namespace phpFastCache\Drivers\Zendhm;
+namespace phpFastCache\Drivers\Zendshm;
 
 use phpFastCache\Cache\ExtendedCacheItemInterface;
 use phpFastCache\Cache\ExtendedCacheItemPoolInterface;


### PR DESCRIPTION
I have added the Zend Data Cache Functions for ZendServer, use new cache functions: zend_shm_cache and zend_diskcache.
See:
http://files.zend.com/help/Zend-Server/content/zendserverapi/zend_data_cache-php_api.htm#function-zend_shm_cache_info

