### PR TITLE
Performance improvement for Directory::getAbsolutePath()

### DIFF
--- a/src/phpFastCache/Util/Directory.php
+++ b/src/phpFastCache/Util/Directory.php
@@ -120,8 +120,7 @@ class Directory
      */
     public static function getAbsolutePath($path)
     {
-        $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
-        $parts = array_filter(explode(DIRECTORY_SEPARATOR, $path), 'strlen');
+        $parts = preg_split('~[/\\\\]+~', $path, 0, PREG_SPLIT_NO_EMPTY);
         $absolutes = [];
         foreach ($parts as $part) {
             if ('.' === $part) {


### PR DESCRIPTION
# Benchmark script

```php
<?php

$before = microtime(true);

for ($i = 0; $i < 1000000; $i++) {
    $win = getAbsolutePath('C:/1/2//3\4/5');
}

$after = microtime(true);
echo ($after - $before) . " sec\n";

var_dump($win);
```

# Benchmark result

Before PR: 
```
9.4655411243439 sec
string(37) "C:\1\2\3\4\5"
```
After PR: 
```
4.5632607936859 sec
string(37) "C:\1\2\3\4\5"
```
