### PR TITLE
Fix CouchBase driver settings array example

### DIFF
--- a/examples/couchbase.php
+++ b/examples/couchbase.php
@@ -25,10 +25,10 @@ $InstanceCache = CacheManager::getInstance('couchbase', [
   'timeout' => '1',
   'buckets' => [
     [
-      'default' => 'Cache',// The bucket name, generally "default" by default
-      'password' => ''// The bucket password if there is
+      'bucket' => 'default', // The bucket name, generally "default" by default
+      'password' => '' // The bucket password if there is
     ],
-  ],
+  ]
 ]);
 
 /**


### PR DESCRIPTION
'default' => 'Cache' (wrong key 'default', should be 'bucket')
to
'bucket' => 'default'

Took me some time to figure it out, so better change it to more clear example.