### PR TITLE
Clean/delete parent cache dirrectory if it empty after call deleteItem()/deleteItems() for Files driver.

### DIFF
--- a/src/phpFastCache/Drivers/Files/Driver.php
+++ b/src/phpFastCache/Drivers/Files/Driver.php
@@ -138,6 +138,10 @@ class Driver extends DriverAbstract
         if ($item instanceof Item) {
             $file_path = $this->getFilePath($item->getKey(), true);
             if (file_exists($file_path) && @unlink($file_path)) {
+                $dir = dirname($file_path);
+                if (!(new \FilesystemIterator($dir))->valid()) {
+                    rmdir($dir);
+                }
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
Subj.

I found "issue" when I try to clean all Items by tags (for example),
related files in cache path all removed, but parent dir(s) still leaved also if this dir complete empty.

My simple patch fix this for files driver:
 if item file deleted (by @unlink call), also check if parent directory is empty, than also remove this dir too.