### PR TITLE
Clean/delete parent cache directory if it empty after call deleteItem()/deleteItems() for Files driver.

### DIFF
--- a/src/phpFastCache/Drivers/Files/Driver.php
+++ b/src/phpFastCache/Drivers/Files/Driver.php
@@ -118,6 +118,10 @@ class Driver implements ExtendedCacheItemPoolInterface
         if ($item instanceof Item) {
             $file_path = $this->getFilePath($item->getKey(), true);
             if (file_exists($file_path) && @unlink($file_path)) {
+                $dir = dirname($file_path);
+                if (!(new \FilesystemIterator($dir))->valid()) {
+                    rmdir($dir);
+                }
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
Same as in #431