### PR TITLE
Fix mongodb driver

### DIFF
--- a/src/phpFastCache/Drivers/Mongodb/Driver.php
+++ b/src/phpFastCache/Drivers/Mongodb/Driver.php
@@ -54,12 +54,7 @@ class Driver extends DriverAbstract
      */
     public function driverCheck()
     {
-        if(class_exists('MongoDB\Driver\Manager')){
-            trigger_error('PhpFastCache currently only support the pecl Mongo extension.<br />
-            The Support for the MongoDB extension will be added coming soon.', E_USER_ERROR);
-        }
-
-        return extension_loaded('Mongodb') && class_exists('MongoClient');
+        return class_exists('MongoClient');
     }
 
     /**

--- a/src/phpFastCache/Drivers/Mongodb/Driver.php
+++ b/src/phpFastCache/Drivers/Mongodb/Driver.php
@@ -34,11 +34,6 @@ use Psr\Cache\CacheItemInterface;
 class Driver extends DriverAbstract
 {
     /**
-     * @var MongodbClient
-     */
-    public $instance;
-
-    /**
      * Driver constructor.
      * @param array $config
      * @throws phpFastCacheDriverException

--- a/src/phpFastCache/Drivers/Mongodb/Driver.php
+++ b/src/phpFastCache/Drivers/Mongodb/Driver.php
@@ -30,6 +30,7 @@ use Psr\Cache\CacheItemInterface;
 /**
  * Class Driver
  * @package phpFastCache\Drivers
+ * @property MongodbClient $instance Instance of driver service
  */
 class Driver extends DriverAbstract
 {


### PR DESCRIPTION
A fatal error is triggered by inconsistency through "Driver" class and "DriverBaseTrait" trait. The $instance's access modifiers are different. The bug is fixed dropping $instance field from Driver class. 
On the other hand, removing  `class_exists('MongoDB\Driver\Manager)` from the `Driver::driverCheck` method we can open the posibility to add support for the new mongodb library via an adapter like "alcaeus/mongo-php-adapter"