### PR TITLE
Update CouchBase driver connection function with new couchbase PHP SDK 2.4

### DIFF
--- a/docs/examples/couchbase.php
+++ b/docs/examples/couchbase.php
@@ -19,13 +19,11 @@ require __DIR__ . '/../../vendor/autoload.php';
 
 $InstanceCache = CacheManager::getInstance('couchbase', [
   'host' => 'your-couchbase-host',
-  'port' => 8091,
   'username' => 'your-couchbase-username',
   'password' => 'your-couchbase-password',
   'buckets' => [
     [
       'bucket' => 'default', // The bucket name, generally "default" by default
-      'password' => '' // The bucket password if there is
     ],
   ]
 ]);

--- a/src/phpFastCache/Drivers/Couchbase/Driver.php
+++ b/src/phpFastCache/Drivers/Couchbase/Driver.php
@@ -143,23 +143,34 @@ class Driver implements ExtendedCacheItemPoolInterface
             throw new phpFastCacheLogicException('Already connected to Couchbase server');
         } else {
 
-
             $host = isset($this->config[ 'host' ]) ? $this->config[ 'host' ] : '127.0.0.1';
-            $port = isset($this->config[ 'port' ]) ? $this->config[ 'port' ] : 8091;
-            $password = isset($this->config[ 'password' ]) ? $this->config[ 'password' ] : '';
-            $username = isset($this->config[ 'username' ]) ? $this->config[ 'username' ] : '';
+            $port = isset($this->config[ 'port' ]) ? $this->config[ 'port' ] : NULL;
+            $password = isset($this->config[ 'password' ]) ? $this->config[ 'password' ] : NULL;
+            $username = isset($this->config[ 'username' ]) ? $this->config[ 'username' ] : NULL;
             $buckets = isset($this->config[ 'buckets' ]) ? $this->config[ 'buckets' ] : [
               [
                 'bucket' => 'default',
-                'password' => '',
               ],
             ];
+            
+            // Establish username and password for bucket access
+            $authenticator = new \Couchbase\PasswordAuthenticator();
+            $authenticator->username($this->config[ 'username' ])->password($this->config[ 'password' ]);
 
-            $this->instance = new CouchbaseClient("couchbase://{$host}:{$port}", $username, $password);
+            // Connect to Couchbase Server
+            if (isset($port)) {
+                $cluster = new CouchbaseClient("couchbase://" . $host . ":" . $port);
+            } else {
+                $cluster = new CouchbaseClient("couchbase://" . $host);  
+            }
+
+            // Authenticate, then open buckets
+            $cluster->authenticate($authenticator);
+            $this->instance = $this->instance ?: $cluster;
 
             foreach ($buckets as $bucket) {
                 $this->bucketCurrent = $this->bucketCurrent ?: $bucket[ 'bucket' ];
-                $this->setBucket($bucket[ 'bucket' ], $this->instance->openBucket($bucket[ 'bucket' ], $bucket[ 'password' ]));
+                $this->setBucket($bucket[ 'bucket' ], $this->instance->openBucket($bucket[ 'bucket' ]));
             }
         }
 


### PR DESCRIPTION
Port and bucket passwords are no longer required as of CouchBase 5.0, and old connection code is not working due to the new authentification model.

I am using this code right now with new CouchBase server 5.1.0.

It is still possible to use "$port" in configuration array (despite it is no longer required), i leave a check for it - maybe will be useful in some non-standart environment.

Some links:
https://developer.couchbase.com/documentation/server/current/sdk/php/start-using-sdk.html