### PR TITLE
Updated ExtendedCacheItemPoolTrait::deregisterItem() to now only accept string as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/phpfastcache/phpfastcache.svg)](https://packagist.org/packages/phpfastcache/phpfastcache) [![Latest Stable Version](https://img.shields.io/packagist/v/phpfastcache/phpfastcache.svg)](https://packagist.org/packages/phpfastcache/phpfastcache) [![License](https://img.shields.io/packagist/l/phpfastcache/phpfastcache.svg)](https://packagist.org/packages/phpfastcache/phpfastcache) [![Coding Standards](https://img.shields.io/badge/CI-PSR6-orange.svg)](https://github.com/php-fig/cache)  [![Coding Standards](https://img.shields.io/badge/CS-PSR16-orange.svg)](https://github.com/php-fig/simple-cache)    
 [![Code Climate](https://codeclimate.com/github/PHPSocialNetwork/phpfastcache/badges/gpa.svg)](https://codeclimate.com/github/PHPSocialNetwork/phpfastcache) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/PHPSocialNetwork/phpfastcache/badges/quality-score.png?b=final)](https://scrutinizer-ci.com/g/PHPSocialNetwork/phpfastcache/?branch=final) [![Build Status](https://travis-ci.org/PHPSocialNetwork/phpfastcache.svg?branch=final)](https://travis-ci.org/PHPSocialNetwork/phpfastcache) [![Semver compliant](https://img.shields.io/badge/Semver-2.0.0-yellow.svg)](https://semver.org/spec/v2.0.0.html) [![Patreon](https://img.shields.io/badge/Support%20us%20on-Patreon-f96854.svg)](https://www.patreon.com/geolim4)
 
-:exclamation: V6 USERS, PLEASE NOTE THAT THE V6 REQUIRES PHP 5.6 AT LEAST :exclamation:
+> :exclamation: V6 USERS, PLEASE NOTE THAT THE V6 REQUIRES PHP 5.6 AT LEAST :exclamation:\
+Also please be aware that the V7 was released on the 01 june 2018, therefore you should check\
+your dependencies constraints as this release is absolutely not compatible with the current (V6)
 
 ---------------------------
 Simple Yet Powerful PHP Caching Class

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "ext-sqlite": "*",
         "ext-wincache": "*",
         "ext-leveldb": "*",
+        "ext-couchbase": "*",
         "predis/predis": "~1.1.0",
         "mongodb/mongodb": "^1.1",
         "phpfastcache/phpssdb": "~1.0.0",

--- a/src/phpFastCache/Core/Item/ItemBaseTrait.php
+++ b/src/phpFastCache/Core/Item/ItemBaseTrait.php
@@ -40,17 +40,17 @@ trait ItemBaseTrait
     protected $data;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $expirationDate;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $creationDate;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $modificationDate;
 

--- a/src/phpFastCache/Core/Item/ItemExtendedTrait.php
+++ b/src/phpFastCache/Core/Item/ItemExtendedTrait.php
@@ -22,9 +22,9 @@ use phpFastCache\Exceptions\phpFastCacheLogicException;
 /**
  * Class ItemExtendedTrait
  * @package phpFastCache\Core\Item
- * @property \Datetime $expirationDate Expiration date of the item
- * @property \Datetime $creationDate Creation date of the item
- * @property \Datetime $modificationDate Modification date of the item
+ * @property \DateTimeInterface $expirationDate Expiration date of the item
+ * @property \DateTimeInterface $creationDate Creation date of the item
+ * @property \DateTimeInterface $modificationDate Modification date of the item
  * @property mixed $data Data of the item
  * @property bool $fetched Fetch flag status
  * @property array $tags The tags array

--- a/src/phpFastCache/Core/Pool/ExtendedCacheItemPoolTrait.php
+++ b/src/phpFastCache/Core/Pool/ExtendedCacheItemPoolTrait.php
@@ -379,7 +379,7 @@ trait ExtendedCacheItemPoolTrait
     public function detachItem(CacheItemInterface $item)
     {
         if (isset($this->itemInstances[ $item->getKey() ])) {
-            $this->deregisterItem($item->get());
+            $this->deregisterItem($item->getKey());
         }
     }
 

--- a/src/phpFastCache/Core/Pool/ExtendedCacheItemPoolTrait.php
+++ b/src/phpFastCache/Core/Pool/ExtendedCacheItemPoolTrait.php
@@ -379,7 +379,7 @@ trait ExtendedCacheItemPoolTrait
     public function detachItem(CacheItemInterface $item)
     {
         if (isset($this->itemInstances[ $item->getKey() ])) {
-            $this->deregisterItem($item);
+            $this->deregisterItem($item->get());
         }
     }
 
@@ -408,15 +408,12 @@ trait ExtendedCacheItemPoolTrait
 
     /**
      * @internal This method de-register an item from $this->itemInstances
-     * @param CacheItemInterface|string $item
+     * @param string $item
      * @throws phpFastCacheInvalidArgumentException
      */
     protected function deregisterItem($item)
     {
-        if ($item instanceof CacheItemInterface) {
-            unset($this->itemInstances[ $item->getKey() ]);
-
-        } else if (is_string($item)) {
+        if (is_string($item)) {
             unset($this->itemInstances[ $item ]);
         } else {
             throw new phpFastCacheInvalidArgumentException('Invalid type for $item variable');


### PR DESCRIPTION
- Fixed Datetime type hints in ItemExtendedTrait
- Fixed Datetime type hints in ItemBaseTrait
- Updated README to warn users about v7 compatibility
- Added "ext-couchbase" suggestion
