### PR TITLE
Support Mongodb Cluster and add uri options.

### DIFF
--- a/lib/Phpfastcache/Drivers/Mongodb/Config.php
+++ b/lib/Phpfastcache/Drivers/Mongodb/Config.php
@@ -210,8 +210,7 @@ class Config extends ConfigurationOption
     }
 
     /**
-     * https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options
-     *
+     * @see https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options
      * @param array $options
      * @return Config
      */

--- a/lib/Phpfastcache/Drivers/Mongodb/Config.php
+++ b/lib/Phpfastcache/Drivers/Mongodb/Config.php
@@ -38,9 +38,9 @@ class Config extends ConfigurationOption
     protected $password = '';
 
     /**
-     * @var string
+     * @var array
      */
-    protected $servers = '';
+    protected $servers = [];
 
     /**
      * @var string
@@ -51,6 +51,11 @@ class Config extends ConfigurationOption
      * @var string
      */
     protected $databaseName = Driver::MONGODB_DEFAULT_DB_NAME;
+
+    /**
+     * @var array
+     */
+    protected $options = [];
 
     /**
      * @return string
@@ -145,7 +150,7 @@ class Config extends ConfigurationOption
     /**
      * @return string
      */
-    public function getServers(): string
+    public function getServers(): array
     {
         return $this->servers;
     }
@@ -154,7 +159,7 @@ class Config extends ConfigurationOption
      * @param string $servers
      * @return self
      */
-    public function setServers(string $servers): self
+    public function setServers(array $servers): self
     {
         $this->servers = $servers;
         return $this;
@@ -193,6 +198,26 @@ class Config extends ConfigurationOption
     public function setDatabaseName(string $databaseName): self
     {
         $this->databaseName = $databaseName;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options
+     *
+     * @param array $options
+     * @return Config
+     */
+    public function setOptions(array $options): self
+    {
+        $this->options = $options;
         return $this;
     }
 }

--- a/lib/Phpfastcache/Drivers/Mongodb/Driver.php
+++ b/lib/Phpfastcache/Drivers/Mongodb/Driver.php
@@ -224,10 +224,21 @@ class Driver implements ExtendedCacheItemPoolInterface
      */
     protected function buildConnectionURI($databaseName = ''): string
     {
+        $servers = $this->getConfig()->getServers();
+        $options = $this->getConfig()->getOptions();
+
         $host = $this->getConfig()->getHost();
         $port = $this->getConfig()->getPort();
         $username = $this->getConfig()->getUsername();
         $password = $this->getConfig()->getPassword();
+
+        if( \count($servers) > 0 ){
+            $host = array_reduce($servers, function($carry, $data){
+                $carry .= ($carry === '' ? '' : ',').$data['host'].':'.$data['port'];
+                return $carry;
+            }, '');
+            $port = false;
+        }
 
         return implode('', [
             'mongodb://',
@@ -235,8 +246,9 @@ class Driver implements ExtendedCacheItemPoolInterface
             ($password ? ":{$password}" : ''),
             ($username ? '@' : ''),
             $host,
-            ($port !== 27017 ? ":{$port}" : ''),
+            ($port !== 27017 && $port !== false ? ":{$port}" : ''),
             ($databaseName ? "/{$databaseName}" : ''),
+            (count($options) > 0 ? '?'.http_build_query($options) : ''),
         ]);
     }
 

--- a/lib/Phpfastcache/Drivers/Mongodb/Driver.php
+++ b/lib/Phpfastcache/Drivers/Mongodb/Driver.php
@@ -233,7 +233,7 @@ class Driver implements ExtendedCacheItemPoolInterface
         $password = $this->getConfig()->getPassword();
 
         if( \count($servers) > 0 ){
-            $host = array_reduce($servers, function($carry, $data){
+            $host = \array_reduce($servers, function($carry, $data){
                 $carry .= ($carry === '' ? '' : ',').$data['host'].':'.$data['port'];
                 return $carry;
             }, '');
@@ -248,7 +248,7 @@ class Driver implements ExtendedCacheItemPoolInterface
             $host,
             ($port !== 27017 && $port !== false ? ":{$port}" : ''),
             ($databaseName ? "/{$databaseName}" : ''),
-            (count($options) > 0 ? '?'.http_build_query($options) : ''),
+            (\count($options) > 0 ? '?'.\http_build_query($options) : ''),
         ]);
     }
 


### PR DESCRIPTION
## Proposed changes

The MongoDB Driver, powered by phpfastcache, is designed to function properly when the MongoDB connection is a single server or custom make host string.

You can make your host a string and connect it directly, but you modified it to support it in your library because it could potentially cause developers to make mistakes.

The method of use allows you to add a list of servers to a servers variable, similar to memcached, so that you can add them automatically. 

We can also explicitly add options to the mongodb urI policy, but we did not support it, so we also worked on adding that data.
(https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options)

The changes include :

## Types of changes

What types of changes does your code introduce to Phpfastcache?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Deprecated third party dependency update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
