### PR TITLE
fixed bug in Apcu driver.

### DIFF
--- a/lib/Phpfastcache/Drivers/Apcu/Driver.php
+++ b/lib/Phpfastcache/Drivers/Apcu/Driver.php
@@ -127,6 +127,6 @@ class Driver implements ExtendedCacheItemPoolInterface
             ->setInfo(\sprintf("The APCU cache is up since %s, and have %d item(s) in cache.\n For more information see RawData.", $date->format(\DATE_RFC2822),
                 $stats['num_entries']))
             ->setRawData($stats)
-            ->setSize($stats['mem_size']);
+            ->setSize((int)$stats['mem_size']);
     }
 }


### PR DESCRIPTION
## Proposed changes

The Apcu driver passes `$stats['mem_size']` to the function `setSize()` of `DriverStatistic`. This generates an error due to type mismatch. The function `setSize()` expects and integer while `$stats['mem_size']` is a float.

## Types of changes

What types of changes does your code introduce to Phpfastcache?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
