### PR TITLE
Moved exclusive files-related configurations keys to IOConfigurationTrait

### DIFF
--- a/lib/Phpfastcache/CacheManager.php
+++ b/lib/Phpfastcache/CacheManager.php
@@ -370,6 +370,9 @@ class CacheManager
     }
 
     /**
+     * Return the list of available drivers Capitalized
+     * with optional FQCN as key
+     *
      * @param bool $FQCNAsKey Describe keys with Full Qualified Class Name
      * @return string[]
      * @throws PhpfastcacheUnsupportedOperationException

--- a/lib/Phpfastcache/Config/ConfigurationOption.php
+++ b/lib/Phpfastcache/Config/ConfigurationOption.php
@@ -93,14 +93,12 @@ class ConfigurationOption extends ArrayObject implements ConfigurationOptionInte
      */
     protected $cacheSlamsTimeout = 15;
 
-    /**
-     * @var string
-     */
-    protected $cacheFileExtension = 'txt';
 
     /**
      * @param $args
      * ArrayObject constructor.
+     * @throws PhpfastcacheInvalidConfigurationException
+     * @throws \ReflectionException
      */
     public function __construct(...$args)
     {
@@ -267,7 +265,7 @@ class ConfigurationOption extends ArrayObject implements ConfigurationOptionInte
      * @return ConfigurationOption
      * @throws  PhpfastcacheInvalidConfigurationException
      */
-    public function setDefaultKeyHashFunction($defaultKeyHashFunction)
+    public function setDefaultKeyHashFunction($defaultKeyHashFunction): self
     {
         if (!\is_callable($defaultKeyHashFunction) && (\is_string($defaultKeyHashFunction) && !\function_exists($defaultKeyHashFunction))) {
             throw new PhpfastcacheInvalidConfigurationException('defaultKeyHashFunction must be a valid function name string');
@@ -285,11 +283,11 @@ class ConfigurationOption extends ArrayObject implements ConfigurationOptionInte
     }
 
     /**
-     * @param Callable|string $defaultKeyHashFunction
+     * @param Callable|string $defaultFileNameHashFunction
      * @return ConfigurationOption
      * @throws  PhpfastcacheInvalidConfigurationException
      */
-    public function setDefaultFileNameHashFunction($defaultFileNameHashFunction)
+    public function setDefaultFileNameHashFunction($defaultFileNameHashFunction): self
     {
         if (!\is_callable($defaultFileNameHashFunction) && (\is_string($defaultFileNameHashFunction) && !\function_exists($defaultFileNameHashFunction))) {
             throw new PhpfastcacheInvalidConfigurationException('defaultFileNameHashFunction must be a valid function name string');
@@ -363,13 +361,14 @@ class ConfigurationOption extends ArrayObject implements ConfigurationOptionInte
     /**
      * @param \Phpfastcache\Config\ConfigurationOption|null $fallbackConfig
      * @return ConfigurationOption
+     * @throws PhpfastcacheInvalidArgumentException
      */
     public function setFallbackConfig($fallbackConfig): self
     {
         if ($fallbackConfig !== null && !($fallbackConfig instanceof self)) {
             throw new PhpfastcacheInvalidArgumentException(\sprintf(
                 'Invalid argument "%s" for %s',
-                \gettype($fallbackConfig) === 'object' ? \get_class($fallbackConfig) : \gettype($fallbackConfig),
+                \is_object($fallbackConfig) ? \get_class($fallbackConfig) : \gettype($fallbackConfig),
                 __METHOD__
             ));
         }
@@ -446,45 +445,6 @@ class ConfigurationOption extends ArrayObject implements ConfigurationOptionInte
     public function setCacheSlamsTimeout(int $cacheSlamsTimeout): self
     {
         $this->cacheSlamsTimeout = $cacheSlamsTimeout;
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCacheFileExtension(): string
-    {
-        return $this->cacheFileExtension;
-    }
-
-    /**
-     * @param string $cacheFileExtension
-     * @return ConfigurationOption
-     * @throws PhpfastcacheInvalidConfigurationException
-     */
-    public function setCacheFileExtension(string $cacheFileExtension): self
-    {
-        /**
-         * Feel free to propose your own one
-         * by opening a pull request :)
-         */
-        static $safeFileExtensions = [
-            'txt',
-            'cache',
-            'db',
-            'pfc',
-        ];
-
-        if (\strpos($cacheFileExtension, '.') !== false) {
-            throw new PhpfastcacheInvalidConfigurationException('cacheFileExtension cannot contain a dot "."');
-        }
-        if (!\in_array($cacheFileExtension, $safeFileExtensions, true)) {
-            throw new PhpfastcacheInvalidConfigurationException(
-                "Extension \"{$cacheFileExtension}\" is not safe, currently allowed extension names: " . \implode(', ', $safeFileExtensions)
-            );
-        }
-
-        $this->cacheFileExtension = $cacheFileExtension;
         return $this;
     }
 }

--- a/lib/Phpfastcache/Config/IOConfigurationOptionTrait.php
+++ b/lib/Phpfastcache/Config/IOConfigurationOptionTrait.php
@@ -14,6 +14,10 @@
 declare(strict_types=1);
 namespace Phpfastcache\Config;
 
+use Phpfastcache\Exceptions\PhpfastcacheInvalidConfigurationException;
+
+const SAFE_FILE_EXTENSIONS = 'txt|cache|db|pfc';
+
 trait IOConfigurationOptionTrait
 {
     /**
@@ -32,6 +36,11 @@ trait IOConfigurationOptionTrait
     protected $securityKey = '';
 
     /**
+     * @var string
+     */
+    protected $cacheFileExtension = 'txt';
+
+    /**
      * @return string
      */
     public function getSecurityKey(): string
@@ -43,7 +52,7 @@ trait IOConfigurationOptionTrait
      * @param string $securityKey
      * @return Config
      */
-    public function setSecurityKey(string $securityKey): ConfigurationOptionInterface
+    public function setSecurityKey(string $securityKey): self
     {
         $this->securityKey = $securityKey;
 
@@ -81,9 +90,44 @@ trait IOConfigurationOptionTrait
      * @param bool $secureFileManipulation
      * @return self
      */
-    public function setSecureFileManipulation(bool $secureFileManipulation): ConfigurationOptionInterface
+    public function setSecureFileManipulation(bool $secureFileManipulation): self
     {
         $this->secureFileManipulation = $secureFileManipulation;
+        return $this;
+    }
+
+
+    /**
+     * @return string
+     */
+    public function getCacheFileExtension(): string
+    {
+        return $this->cacheFileExtension;
+    }
+
+    /**
+     * @param string $cacheFileExtension
+     * @return self
+     * @throws PhpfastcacheInvalidConfigurationException
+     */
+    public function setCacheFileExtension(string $cacheFileExtension): self
+    {
+        /**
+         * Feel free to propose your own one
+         * by opening a pull request :)
+         */
+        $safeFileExtensions = \explode('|', SAFE_FILE_EXTENSIONS);
+
+        if (\strpos($cacheFileExtension, '.') !== false) {
+            throw new PhpfastcacheInvalidConfigurationException('cacheFileExtension cannot contain a dot "."');
+        }
+        if (!\in_array($cacheFileExtension, $safeFileExtensions, true)) {
+            throw new PhpfastcacheInvalidConfigurationException(
+                "Extension \"{$cacheFileExtension}\" is not safe, currently allowed extension names: " . \implode(', ', $safeFileExtensions)
+            );
+        }
+
+        $this->cacheFileExtension = $cacheFileExtension;
         return $this;
     }
 }

--- a/tests/issues/Github-467.test.php
+++ b/tests/issues/Github-467.test.php
@@ -6,31 +6,31 @@
  */
 
 use Phpfastcache\CacheManager;
-use Phpfastcache\Config\ConfigurationOption;
+use Phpfastcache\Drivers\Files\Config as FilesConfig;
 use Phpfastcache\Exceptions\PhpfastcacheInvalidConfigurationException;
 use Phpfastcache\Helper\TestHelper;
 
 chdir(__DIR__);
 require_once __DIR__ . '/../../vendor/autoload.php';
 $testHelper = new TestHelper('Github issue #467 - Allow to specify the file extension in the File Driver');
-CacheManager::setDefaultConfig(new ConfigurationOption(['path' => __DIR__ . '/../../cache']));
+CacheManager::setDefaultConfig(new FilesConfig(['path' => __DIR__ . '/../../cache']));
 
 try{
-    $cacheInstance = CacheManager::getInstance('Files', new ConfigurationOption(['cacheFileExtension' => 'php']));
+    $cacheInstance = CacheManager::getInstance('Files', new FilesConfig(['cacheFileExtension' => 'php']));
     $testHelper->printFailText('No error thrown while trying to setup a dangerous file extension');
 }catch(PhpfastcacheInvalidConfigurationException $e){
     $testHelper->printPassText('An error has been thrown while trying to setup a dangerous file extension');
 }
 
 try{
-    $cacheInstance = CacheManager::getInstance('Files', new ConfigurationOption(['cacheFileExtension' => '.cache']));
+    $cacheInstance = CacheManager::getInstance('Files', new FilesConfig(['cacheFileExtension' => '.cache']));
     $testHelper->printFailText('No error thrown while trying to setup a dotted file extension');
 }catch(PhpfastcacheInvalidConfigurationException $e){
     $testHelper->printPassText('An error has been thrown while trying to setup a dotted file extension');
 }
 
 try{
-    $cacheInstance = CacheManager::getInstance('Files', new ConfigurationOption(['cacheFileExtension' => 'cache']));
+    $cacheInstance = CacheManager::getInstance('Files', new FilesConfig(['cacheFileExtension' => 'cache']));
     $testHelper->printPassText('No error thrown while trying to setup a safe file extension');
 }catch(PhpfastcacheInvalidConfigurationException $e){
     $testHelper->printFailText('An error has been thrown while trying to setup a safe file extension');


### PR DESCRIPTION
## Proposed changes

Moved exclusive files-related configurations keys to IOConfigurationTrait

## Types of changes

What types of changes does your code introduce to Phpfastcache?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
