### PR TITLE
Add mongo db driver options

### DIFF
--- a/lib/Phpfastcache/Drivers/Mongodb/Config.php
+++ b/lib/Phpfastcache/Drivers/Mongodb/Config.php
@@ -156,7 +156,7 @@ class Config extends ConfigurationOption
     }
 
     /**
-     * @return string
+     * @return array
      */
     public function getServers(): array
     {
@@ -164,7 +164,7 @@ class Config extends ConfigurationOption
     }
 
     /**
-     * @param string $servers
+     * @param array $servers
      * @return self
      */
     public function setServers(array $servers): self

--- a/lib/Phpfastcache/Drivers/Mongodb/Config.php
+++ b/lib/Phpfastcache/Drivers/Mongodb/Config.php
@@ -66,6 +66,11 @@ class Config extends ConfigurationOption
     protected $options = [];
 
     /**
+     * @var array
+     */
+    protected $driverOptions = [];
+
+    /**
      * @return string
      */
     public function getHost(): string
@@ -225,6 +230,24 @@ class Config extends ConfigurationOption
     public function setOptions(array $options): self
     {
         $this->options = $options;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDriverOptions(): array
+    {
+        return $this->driverOptions;
+    }
+
+    /**
+     * @param array $driverOptions
+     * @return self
+     */
+    public function setDriverOptions(array $driverOptions): self
+    {
+        $this->driverOptions = $driverOptions;
         return $this;
     }
 }

--- a/lib/Phpfastcache/Drivers/Mongodb/Driver.php
+++ b/lib/Phpfastcache/Drivers/Mongodb/Driver.php
@@ -185,8 +185,9 @@ class Driver implements ExtendedCacheItemPoolInterface
         $timeout = $this->getConfig()->getTimeout() * 1000;
         $collectionName = $this->getConfig()->getCollectionName();
         $databaseName = $this->getConfig()->getDatabaseName();
+        $driverOptions = $this->getConfig()->getDriverOptions();
 
-        $this->instance = $this->instance ?: new Client($this->buildConnectionURI($databaseName), ['connectTimeoutMS' => $timeout]);
+        $this->instance = $this->instance ?: new Client($this->buildConnectionURI($databaseName), ['connectTimeoutMS' => $timeout], $driverOptions);
         $this->database = $this->database ?: $this->instance->selectDatabase($databaseName);
 
         if (!$this->collectionExists($collectionName)) {


### PR DESCRIPTION
## Proposed changes

Adds the possibility to pass the `$driverOptions`parameter while building the MongoDB Client.
See related issue: https://github.com/PHPSocialNetwork/phpfastcache/issues/663

## Types of changes

What types of changes does your code introduce to Phpfastcache?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs
