### PR TITLE
[v6] Fix composer package name should be all lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ As Fast To Implement As Opening a Beer
 
 
 ```bash
-composer require phpFastCache/phpFastCache
+composer require phpfastcache/phpfastcache
 ```
 
 #### :construction: Step 2: Setup your website code to implement the phpFastCache calls (with Composer)


### PR DESCRIPTION
## Proposed changes

Composer 1.8.2 (latest) would now emit a deprecation warning that package name should in lowercase.

So I think it would be better to change the install command in the README.

```
Deprecation warning: require.phpFastCache/phpfastcache is invalid, it should not contain uppercase characters. 
Please use phpfastcache/phpfastcache instead. Make sure you fix this as Composer 2.0 will error.
```

## Types of changes

What types of changes does your code introduce to Phpfastcache?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs
