### PR TITLE
Minor bug - fatal error in psr16 adapter if an exception is thrown

### DIFF
--- a/lib/Phpfastcache/Drivers/Couchdb/Driver.php
+++ b/lib/Phpfastcache/Drivers/Couchdb/Driver.php
@@ -93,7 +93,7 @@ class Driver implements ExtendedCacheItemPoolInterface
         try {
             $response = $this->instance->findDocument($item->getEncodedKey());
         } catch (CouchDBException $e) {
-            throw new PhpfastcacheDriverException('Got error while trying to get a document: ' . $e->getMessage(), null, $e);
+            throw new PhpfastcacheDriverException('Got error while trying to get a document: ' . $e->getMessage(), 0, $e);
         }
 
         if ($response->status === 404 || empty($response->body['data'])) {
@@ -124,7 +124,7 @@ class Driver implements ExtendedCacheItemPoolInterface
                 $this->instance->putDocument(['data' => $this->encode($this->driverPreWrap($item))], $item->getEncodedKey(),
                     $this->getLatestDocumentRevision($item->getEncodedKey()));
             } catch (CouchDBException $e) {
-                throw new PhpfastcacheDriverException('Got error while trying to upsert a document: ' . $e->getMessage(), null, $e);
+                throw new PhpfastcacheDriverException('Got error while trying to upsert a document: ' . $e->getMessage(), 0, $e);
             }
             return true;
         }
@@ -147,7 +147,7 @@ class Driver implements ExtendedCacheItemPoolInterface
             try {
                 $this->instance->deleteDocument($item->getEncodedKey(), $this->getLatestDocumentRevision($item->getEncodedKey()));
             } catch (CouchDBException $e) {
-                throw new PhpfastcacheDriverException('Got error while trying to delete a document: ' . $e->getMessage(), null, $e);
+                throw new PhpfastcacheDriverException('Got error while trying to delete a document: ' . $e->getMessage(), 0, $e);
             }
             return true;
         }
@@ -165,7 +165,7 @@ class Driver implements ExtendedCacheItemPoolInterface
             $this->instance->deleteDatabase($this->getDatabaseName());
             $this->createDatabase();
         } catch (CouchDBException $e) {
-            throw new PhpfastcacheDriverException('Got error while trying to delete and recreate the database: ' . $e->getMessage(), null, $e);
+            throw new PhpfastcacheDriverException('Got error while trying to delete and recreate the database: ' . $e->getMessage(), 0, $e);
         }
 
         return true;

--- a/lib/Phpfastcache/Drivers/Mongodb/Driver.php
+++ b/lib/Phpfastcache/Drivers/Mongodb/Driver.php
@@ -132,7 +132,7 @@ class Driver implements ExtendedCacheItemPoolInterface
                     ['upsert' => true, 'multiple' => false]
                 );
             } catch (MongoDBException $e) {
-                throw new PhpfastcacheDriverException('Got an exception while trying to write data to MongoDB server', null, $e);
+                throw new PhpfastcacheDriverException('Got an exception while trying to write data to MongoDB server', 0, $e);
             }
 
             return isset($result['ok']) ? $result['ok'] == 1 : true;

--- a/lib/Phpfastcache/Helper/Psr16Adapter.php
+++ b/lib/Phpfastcache/Helper/Psr16Adapter.php
@@ -69,7 +69,7 @@ class Psr16Adapter implements CacheInterface
 
             return $default;
         } catch (PhpfastcacheInvalidArgumentException $e) {
-            throw new PhpfastcacheSimpleCacheException($e->getMessage(), null, $e);
+            throw new PhpfastcacheSimpleCacheException($e->getMessage(), 0, $e);
         }
     }
 
@@ -93,7 +93,7 @@ class Psr16Adapter implements CacheInterface
             }
             return $this->internalCacheInstance->save($cacheItem);
         } catch (PhpfastcacheInvalidArgumentException $e) {
-            throw new PhpfastcacheSimpleCacheException($e->getMessage(), null, $e);
+            throw new PhpfastcacheSimpleCacheException($e->getMessage(), 0, $e);
         }
     }
 
@@ -107,7 +107,7 @@ class Psr16Adapter implements CacheInterface
         try {
             return $this->internalCacheInstance->deleteItem($key);
         } catch (PhpfastcacheInvalidArgumentException $e) {
-            throw new PhpfastcacheSimpleCacheException($e->getMessage(), null, $e);
+            throw new PhpfastcacheSimpleCacheException($e->getMessage(), 0, $e);
         }
     }
 
@@ -120,7 +120,7 @@ class Psr16Adapter implements CacheInterface
         try {
             return $this->internalCacheInstance->clear();
         } catch (PhpfastcacheRootException $e) {
-            throw new PhpfastcacheSimpleCacheException($e->getMessage(), null, $e);
+            throw new PhpfastcacheSimpleCacheException($e->getMessage(), 0, $e);
         }
     }
 
@@ -137,7 +137,7 @@ class Psr16Adapter implements CacheInterface
                 return $item->get();
             }, $this->internalCacheInstance->getItems($keys));
         } catch (PhpfastcacheInvalidArgumentException $e) {
-            throw new PhpfastcacheSimpleCacheException($e->getMessage(), null, $e);
+            throw new PhpfastcacheSimpleCacheException($e->getMessage(), 0, $e);
         }
     }
 
@@ -163,7 +163,7 @@ class Psr16Adapter implements CacheInterface
             }
             return $this->internalCacheInstance->commit();
         } catch (PhpfastcacheInvalidArgumentException $e) {
-            throw new PhpfastcacheSimpleCacheException($e->getMessage(), null, $e);
+            throw new PhpfastcacheSimpleCacheException($e->getMessage(), 0, $e);
         }
     }
 
@@ -177,7 +177,7 @@ class Psr16Adapter implements CacheInterface
         try {
             return $this->internalCacheInstance->deleteItems($keys);
         } catch (PhpfastcacheInvalidArgumentException $e) {
-            throw new PhpfastcacheSimpleCacheException($e->getMessage(), null, $e);
+            throw new PhpfastcacheSimpleCacheException($e->getMessage(), 0, $e);
         }
     }
 
@@ -192,7 +192,7 @@ class Psr16Adapter implements CacheInterface
             $cacheItem = $this->internalCacheInstance->getItem($key);
             return $cacheItem->isHit() && !$cacheItem->isExpired();
         } catch (PhpfastcacheInvalidArgumentException $e) {
-            throw new PhpfastcacheSimpleCacheException($e->getMessage(), null, $e);
+            throw new PhpfastcacheSimpleCacheException($e->getMessage(), 0, $e);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

There is an minor bug in the psr16 adapter, the couchdb driver and the mongodb driver.

You throw multiple exceptions with code "NULL". But this will trigger a fatal error in strict mode: https://3v4l.org/fimJH

## Types of changes

What types of changes does your code introduce to Phpfastcache?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs
