### PR TITLE
Fix for Zend Server SHM & Disk

### DIFF
--- a/lib/Phpfastcache/Core/Item/ItemBaseTrait.php
+++ b/lib/Phpfastcache/Core/Item/ItemBaseTrait.php
@@ -148,7 +148,8 @@ trait ItemBaseTrait
      */
     public function expiresAt($expiration): ExtendedCacheItemInterface
     {
-        if ($expiration instanceof \DateTimeInterface) {
+        if ($expiration instanceof \DateTimeInterface)
+        {
             /**
              * @eventName CacheItemExpireAt
              * @param ExtendedCacheItemInterface $this
@@ -156,7 +157,17 @@ trait ItemBaseTrait
              */
             $this->eventManager->dispatch('CacheItemExpireAt', $this, $expiration);
             $this->expirationDate = $expiration;
-        } else {
+        }
+        elseif(is_array($expiration) && key_exists("date", $expiration)
+            && key_exists("timezone_type", $expiration) && key_exists("timezone", $expiration)
+        ){
+            /**
+             * Hack for Zend Server and PhpfastcacheInvalidArgumentException $expiration must be an object implementing the DateTimeInterface got: array
+             */
+            \DateTime::__set_state($expiration);
+        }
+        else
+        {
             throw new PhpfastcacheInvalidArgumentException('$expiration must be an object implementing the DateTimeInterface got: ' . \gettype($expiration));
         }
 


### PR DESCRIPTION
We had problems with the function expiresAt(), which set the expires time while using ZendCache did not return DateTimeInterface object but an array, which resulted in errors.

We hope you can use this correction.

Greetings Lucas

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.\
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Phpfastcache?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
