### PR TITLE
ssdb-server 1.9.7

### DIFF
--- a/lib/Phpfastcache/Drivers/Ssdb/Driver.php
+++ b/lib/Phpfastcache/Drivers/Ssdb/Driver.php
@@ -100,7 +100,7 @@ class Driver implements ExtendedCacheItemPoolInterface
          * Check for Cross-Driver type confusion
          */
         if ($item instanceof Item) {
-            return $this->instance->setx($item->getEncodedKey(), $this->encode($this->driverPreWrap($item)), $item->getTtl());
+            return (bool) $this->instance->setx($item->getEncodedKey(), $this->encode($this->driverPreWrap($item)), $item->getTtl());
         }
 
         throw new PhpfastcacheInvalidArgumentException('Cross-Driver type confusion detected');

--- a/lib/Phpfastcache/Drivers/Ssdb/Driver.php
+++ b/lib/Phpfastcache/Drivers/Ssdb/Driver.php
@@ -117,7 +117,7 @@ class Driver implements ExtendedCacheItemPoolInterface
          * Check for Cross-Driver type confusion
          */
         if ($item instanceof Item) {
-            return $this->instance->del($item->getEncodedKey());
+            return (bool) $this->instance->del($item->getEncodedKey());
         }
 
         throw new PhpfastcacheInvalidArgumentException('Cross-Driver type confusion detected');
@@ -128,7 +128,7 @@ class Driver implements ExtendedCacheItemPoolInterface
      */
     protected function driverClear(): bool
     {
-        return $this->instance->flushdb('kv');
+        return (bool) $this->instance->flushdb('kv');
     }
 
     /********************


### PR DESCRIPTION
On this version the server return 0 or 1

## Proposed changes

In version 1.9.7 of ssdb, it replies with an integer instead of a Bolean generating the following error:
"Return value of Phpfastcache Drivers SSdb Driver :: driverWrite () must be of the type boolean, integer returned"

## Types of changes

What types of changes does your code introduce to Phpfastcache?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
