### PR TITLE
Fixed TypeError in lib/Phpfastcache/Drivers/Cookie/Driver.php

### DIFF
--- a/lib/Phpfastcache/Drivers/Cookie/Driver.php
+++ b/lib/Phpfastcache/Drivers/Cookie/Driver.php
@@ -49,7 +49,7 @@ class Driver implements ExtendedCacheItemPoolInterface
      */
     protected function driverConnect(): bool
     {
-        return !(!\array_key_exists('phpFastCache', $_COOKIE) && !@setcookie('phpFastCache', 1, 10));
+        return !(!\array_key_exists('phpFastCache', $_COOKIE) && !@setcookie('phpFastCache', '1', 10));
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

`docs/examples/cookie.php` in `PHP 7.1.25`. An error has occurred the following.
```
Fatal error: Uncaught TypeError: setcookie() expects parameter 2 to be string, integer given in /Users/admin/PhpstormProjects/SampleProject/vendor/phpfastcache/phpfastcache/lib/Phpfastcache/Drivers/Cookie/Driver.php on line 52

TypeError: setcookie() expects parameter 2 to be string, integer given in /Users/admin/PhpstormProjects/SampleProject/vendor/phpfastcache/phpfastcache/lib/Phpfastcache/Drivers/Cookie/Driver.php on line 52
```

## Types of changes

What types of changes does your code introduce to Phpfastcache?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
