### PR TITLE
Removing superfluous check for unix socket before auth per #730

### DIFF
--- a/lib/Phpfastcache/Drivers/Redis/Driver.php
+++ b/lib/Phpfastcache/Drivers/Redis/Driver.php
@@ -107,10 +107,8 @@ class Driver implements ExtendedCacheItemPoolInterface, AggregatablePoolInterfac
             $this->instance->setOption(RedisClient::OPT_PREFIX, $this->getConfig()->getOptPrefix());
         }
 
-        if (!$this->getConfig()->getPath()) {
-            if ($this->getConfig()->getPassword() && !$this->instance->auth($this->getConfig()->getPassword())) {
-                return false;
-            }
+        if ($this->getConfig()->getPassword() && !$this->instance->auth($this->getConfig()->getPassword())) {
+            return false;
         }
 
         if ($this->getConfig()->getDatabase() !== null) {


### PR DESCRIPTION
## Proposed changes

Allow `phpfastcache` to attempt to authenticate with Redis if connecting through a UNIX socket. This PR fixes #730 

## Types of changes

What types of changes does your code introduce to Phpfastcache?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs
