### PR TITLE
DeleteItemsByTags was ignoring strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ PhpFastCache provides you a lot of useful APIs:
 | `deleteItem($key)`                                              | bool                           | Deletes an item                                                                                  | 
 | `deleteItems(array $keys)`                                      | bool                           | Deletes one or more items                                                                        | 
 | `deleteItemsByTag($tagName)`                                    | bool                           | Deletes items by a tag                                                                           | 
-| `deleteItemsByTags(array $tagNames)`                            | bool                           | Deletes items  by one of multiple tag names                                                      | 
+| `deleteItemsByTags(array $tagNames, int $strategy)`                            | bool                           | Deletes items  by one of multiple tag names                                                      | 
 | `detachItem($item)`                                             | void                           | Detaches an item from the pool                                                                   | 
 | `getConfig()`                                                   | ConfigurationOption            | Returns the configuration object                                                                 | 
 | `getConfigOption($optionName);`                                 | mixed                          | Returns a configuration value by its key `$optionName`                                           | 

--- a/lib/Phpfastcache/Core/Pool/TaggableCacheItemPoolTrait.php
+++ b/lib/Phpfastcache/Core/Pool/TaggableCacheItemPoolTrait.php
@@ -127,8 +127,9 @@ trait TaggableCacheItemPoolTrait
     public function deleteItemsByTags(array $tagNames, int $strategy = TaggableCacheItemPoolInterface::TAG_STRATEGY_ONE): bool
     {
         $return = null;
-        foreach ($tagNames as $tagName) {
-            $result = $this->deleteItemsByTag($tagName, $strategy);
+
+        foreach ($this->getItemsByTags($tagNames, $strategy) as $item) {
+            $result = $this->deleteItem($item->getKey());
             if ($return !== false) {
                 $return = $result;
             }


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.\
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Phpfastcache?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs

## Further comments

`deleteItemsByTags` was calling `deleteItemsByTag` foreach separate tag, ignoring the given strategy
