### PR TITLE
Redis config cannot accept null values as the given example

### DIFF
--- a/lib/Phpfastcache/Drivers/Redis/Config.php
+++ b/lib/Phpfastcache/Drivers/Redis/Config.php
@@ -101,10 +101,11 @@ class Config extends ConfigurationOption
     }
 
     /**
-     * @param string $password
+     * @param string|null $password
+     *
      * @return self
      */
-    public function setPassword(string $password): self
+    public function setPassword(string $password = null): self
     {
         $this->password = $password;
         return $this;
@@ -113,16 +114,17 @@ class Config extends ConfigurationOption
     /**
      * @return int
      */
-    public function getDatabase(): int
+    public function getDatabase(): ?int
     {
         return $this->database;
     }
 
     /**
-     * @param int $database
+     * @param int|null $database
+     *
      * @return self
      */
-    public function setDatabase(int $database): self
+    public function setDatabase(int $database = null): self
     {
         $this->database = $database;
         return $this;

--- a/lib/Phpfastcache/Drivers/Redis/Config.php
+++ b/lib/Phpfastcache/Drivers/Redis/Config.php
@@ -32,12 +32,12 @@ class Config extends ConfigurationOption
     protected $port = 6379;
 
     /**
-     * @var string
+     * @var null|string
      */
     protected $password = '';
 
     /**
-     * @var int
+     * @var null|int
      */
     protected $database = 0;
 
@@ -93,7 +93,7 @@ class Config extends ConfigurationOption
     }
 
     /**
-     * @return mixed
+     * @return null|mixed
      */
     public function getPassword()
     {
@@ -112,7 +112,7 @@ class Config extends ConfigurationOption
     }
 
     /**
-     * @return int
+     * @return null|int
      */
     public function getDatabase(): ?int
     {

--- a/lib/Phpfastcache/Drivers/Redis/Config.php
+++ b/lib/Phpfastcache/Drivers/Redis/Config.php
@@ -93,7 +93,7 @@ class Config extends ConfigurationOption
     }
 
     /**
-     * @return null|mixed
+     * @return null|string
      */
     public function getPassword()
     {


### PR DESCRIPTION
## Proposed changes
According to this [example](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/docs/examples/redis.php), password and database options can be nullable. 
```php

$InstanceCache = CacheManager::getInstance('redis', new Config([
  'host' => '127.0.0.1', //Default value
  'port' => 6379, //Default value
  'password' => null, //Default value
  'database' => null, //Default value
]));

```

For a given server setup I need these values to be null but, the Config setters didn't accept null values and thrown exception.

## Types of changes

What types of changes does your code introduce to Phpfastcache?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs
