### PR TITLE
Allow $cacheItem to be retrieved by callback argument in CacheConditionalHelper

### DIFF
--- a/lib/Phpfastcache/Helper/CacheConditionalHelper.php
+++ b/lib/Phpfastcache/Helper/CacheConditionalHelper.php
@@ -50,7 +50,7 @@ class CacheConditionalHelper
         $cacheItem = $this->cacheInstance->getItem($cacheKey);
 
         if (!$cacheItem->isHit()) {
-            $cacheItem->set($callback());
+            $cacheItem->set($callback($cacheItem));
             if ($expiresAfter) {
                 $cacheItem->expiresAfter($expiresAfter);
             }


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.\
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Phpfastcache?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
