### PR TITLE
Mongodb Driver issue :: Authentification failed

### DIFF
--- a/lib/Phpfastcache/Drivers/Mongodb/Driver.php
+++ b/lib/Phpfastcache/Drivers/Mongodb/Driver.php
@@ -316,8 +316,7 @@ class Driver implements AggregatablePoolInterface
                 $password ? ":{$password}" : '',
                 $username ? '@' : '',
                 $host,
-                $port !== 27017 && $port !== false ? ":{$port}" : '',
-                $databaseName ? "/{$databaseName}" : '',
+                $port !== false ? ":{$port}" : '',
                 count($options) > 0 ? '?' . http_build_query($options) : '',
             ]
         );


### PR DESCRIPTION
# Problem

When I use mongodb driver with bellow config I have error log : `Authentification failed`

```yml
      host: 172.26.0.4
      database: myapp
      collection: cache
      port: 27017
      root:
          login: admin
          password: password
```

# Solution


## Proposed changes

I discover the issue was link to buildConnectionURI, the method return  `mongodb://admin:password@127.0.0.1/myapp`, whereas I'm waiting this : `mongodb://user:password@164.152.09.84:27017` (this second option works for me)

## Types of changes

What types of changes does your code introduce to Phpfastcache?

- [x] Bugfix (non-breaking change which fixes an issue)

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs

## Error log

> PHP 8.1 (Ubuntu)
> mongo:6.0

The full log message : 

```
 Fatal error: Uncaught MongoDB\Driver\Exception\AuthenticationException: Authentication failed. in /Users/toto/Sites/myapp/vendor/mongodb/mongodb/src/Command/ListCollections.php:112 Stack trace: #0 /Users/toto/Sites/myapp/vendor/mongodb/mongodb/src/Command/ListCollections.php(112): MongoDB\Driver\Server->executeReadCommand() #1 /Users/toto/Sites/myapp/vendor/mongodb/mongodb/src/Operation/ListCollections.php(83): MongoDB\Command\ListCollections->execute() #2 /Users/toto/Sites/myapp/vendor/mongodb/mongodb/src/Database.php(466): MongoDB\Operation\ListCollections->execute() #3 /Users/toto/Sites/myapp/vendor/phpfastcache/phpfastcache/lib/Phpfastcache/Drivers/Mongodb/Driver.php(340): MongoDB\Database->listCollections() #4 /Users/toto/Sites/myapp/vendor/phpfastcache/phpfastcache/lib/Phpfastcache/Drivers/Mongodb/Driver.php(93): Phpfastcache\Drivers\Mongodb\Driver->collectionExists() #5 /Users/toto/Sites/myapp/vendor/phpfastcache/phpfastcache/lib/Phpfastcache/Core/Pool/DriverBaseTrait.php(81): Phpfastcache\Drivers\Mongodb\Driver->driverConnect() #6 /Users/toto/Sites/myapp/vendor/phpfastcache/phpfastcache/lib/Phpfastcache/Core/Pool/CacheItemPoolTrait.php(65): Phpfastcache\Drivers\Mongodb\Driver->__driverBaseConstruct() #7 /Users/toto/Sites/myapp/vendor/phpfastcache/phpfastcache/lib/Phpfastcache/CacheManager.php(114): Phpfastcache\Drivers\Mongodb\Driver->__construct() #8 /Users/toto/Sites/CrazyPHP/src/Library/Cache/Cache.php(101): Phpfastcache\CacheManager::getInstance() #9 /Users/toto/Sites/CrazyPHP/src/Core/Router.php(80): CrazyPHP\Library\Cache\Cache->__construct() #10 /Users/toto/Sites/CrazyPHP/src/Core/Core.php(130): CrazyPHP\Core\Router->pushCollection() #11 /Users/toto/Sites/myapp/app/Core/App.php(51): CrazyPHP\Core\Core->runRoutersPreparation() #12 /Users/toto/Sites/myapp/app/Index.php(28): App\Core\App->__construct() #13 /Users/toto/Sites/myapp/public/index.php(24): require_once('...') #14 {main} Next Phpfastcache\Exceptions\PhpfastcacheDriverConnectException: (MongoDB\Driver\Exception\AuthenticationException) Mongodb failed to connect with the following error message: "Authentication failed." line 112 in /Users/toto/Sites/myapp/vendor/mongodb/mongodb/src/Command/ListCollections.php in /Users/toto/Sites/myapp/vendor/phpfastcache/phpfastcache/lib/Phpfastcache/Core/Pool/DriverBaseTrait.php:84 Stack trace: #0 /Users/toto/Sites/myapp/vendor/phpfastcache/phpfastcache/lib/Phpfastcache/Core/Pool/CacheItemPoolTrait.php(65): Phpfastcache\Drivers\Mongodb\Driver->__driverBaseConstruct() #1 /Users/toto/Sites/myapp/vendor/phpfastcache/phpfastcache/lib/Phpfastcache/CacheManager.php(114): Phpfastcache\Drivers\Mongodb\Driver->__construct() #2 /Users/toto/Sites/CrazyPHP/src/Library/Cache/Cache.php(101): Phpfastcache\CacheManager::getInstance() #3 /Users/toto/Sites/CrazyPHP/src/Core/Router.php(80): CrazyPHP\Library\Cache\Cache->__construct() #4 /Users/toto/Sites/CrazyPHP/src/Core/Core.php(130): CrazyPHP\Core\Router->pushCollection() #5 /Users/toto/Sites/myapp/app/Core/App.php(51): CrazyPHP\Core\Core->runRoutersPreparation() #6 /Users/toto/Sites/myapp/app/Index.php(28): App\Core\App->__construct() #7 /Users/toto/Sites/myapp/public/index.php(24): require_once('...') #8 {main} thrown in /Users/toto/Sites/myapp/vendor/phpfastcache/phpfastcache/lib/Phpfastcache/Core/Pool/DriverBaseTrait.php on line 84
```
