### PR TITLE
Refactor Redis driver to read all keys efficiently

### DIFF
--- a/.github/workflows/testsv2.yml
+++ b/.github/workflows/testsv2.yml
@@ -7,7 +7,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        operating-system: [ubuntu-latest]
+        operating-system: [ubuntu-22.04]
         php-versions: ['8.0', '8.1', '8.2', '8.3']
     name: PHP ${{ matrix.php-versions }} quality/tests on ${{ matrix.operating-system }}
     env:

--- a/lib/Phpfastcache/Drivers/Redis/Driver.php
+++ b/lib/Phpfastcache/Drivers/Redis/Driver.php
@@ -125,13 +125,16 @@ class Driver implements AggregatablePoolInterface
      */
     protected function driverReadAllKeys(string $pattern = '*'): iterable
     {
-        $i = -1;
-        $keys = $this->instance->scan($i, $pattern === '' ? '*' : $pattern, ExtendedCacheItemPoolInterface::MAX_ALL_KEYS_COUNT);
-        if (is_iterable($keys)) {
-            return $keys;
-        } else {
-            return [];
-        }
+        $i = null;
+        $keys = [];
+        $pattern = $pattern === '' ? '*' : $pattern;
+        do {
+            $keys = array_merge($keys, $this->instance->scan($i, $pattern));
+            if (sizeof($keys) > ExtendedCacheItemPoolInterface::MAX_ALL_KEYS_COUNT) {
+                break;
+            }
+        } while ($i > 0);
+        return $keys;
     }
 
     /**

--- a/lib/Phpfastcache/Drivers/Redis/Driver.php
+++ b/lib/Phpfastcache/Drivers/Redis/Driver.php
@@ -126,15 +126,14 @@ class Driver implements AggregatablePoolInterface
     protected function driverReadAllKeys(string $pattern = '*'): iterable
     {
         $i = null;
-        $keys = [];
         $pattern = $pattern === '' ? '*' : $pattern;
         do {
-            $keys = array_merge($keys, $this->instance->scan($i, $pattern));
-            if (sizeof($keys) > ExtendedCacheItemPoolInterface::MAX_ALL_KEYS_COUNT) {
+            $keys[] = $this->instance->scan($i, $pattern);
+            if (\count($keys) > ExtendedCacheItemPoolInterface::MAX_ALL_KEYS_COUNT) {
                 break;
             }
         } while ($i > 0);
-        return $keys;
+        return \array_merge([], ...$keys);
     }
 
     /**

--- a/lib/Phpfastcache/Drivers/Rediscluster/Driver.php
+++ b/lib/Phpfastcache/Drivers/Rediscluster/Driver.php
@@ -129,7 +129,7 @@ class Driver implements AggregatablePoolInterface
             $i = 0;
             $pattern = $pattern === '' ? '*' : $pattern;
             do {
-                $result[] = $this->instance->scan($i, $master, $pattern, 10);
+                $result[] = $this->instance->scan($i, $master, $pattern);
                 if (\count($result) > ExtendedCacheItemPoolInterface::MAX_ALL_KEYS_COUNT) {
                     break;
                 }

--- a/lib/Phpfastcache/Drivers/Rediscluster/Driver.php
+++ b/lib/Phpfastcache/Drivers/Rediscluster/Driver.php
@@ -126,7 +126,7 @@ class Driver implements AggregatablePoolInterface
     {
         $result = [[]];
         foreach ($this->instance->_masters() as $master) {
-            $i = null;
+            $i = 0;
             $pattern = $pattern === '' ? '*' : $pattern;
             do {
                 $result[] = $this->instance->scan(

--- a/lib/Phpfastcache/Drivers/Rediscluster/Driver.php
+++ b/lib/Phpfastcache/Drivers/Rediscluster/Driver.php
@@ -129,11 +129,7 @@ class Driver implements AggregatablePoolInterface
             $i = 0;
             $pattern = $pattern === '' ? '*' : $pattern;
             do {
-                $result[] = $this->instance->scan(
-                    $i,
-                    $master,
-                    $pattern,
-                    10);
+                $result[] = $this->instance->scan($i, $master, $pattern, 10);
                 if (\count($result) > ExtendedCacheItemPoolInterface::MAX_ALL_KEYS_COUNT) {
                     break;
                 }

--- a/lib/Phpfastcache/Drivers/Rediscluster/Driver.php
+++ b/lib/Phpfastcache/Drivers/Rediscluster/Driver.php
@@ -62,7 +62,8 @@ class Driver implements AggregatablePoolInterface
                     trim(<<<EOF
                         Redis Cluster version v%s, php-ext v%s with %d master nodes and %d slaves connected are up since %s.
                         For more information see RawData.
-                    EOF),
+                    EOF
+                    ),
                     implode(', ', array_unique(array_column($infos, 'redis_version'))),
                     \phpversion("redis"),
                     count($masters),
@@ -123,21 +124,22 @@ class Driver implements AggregatablePoolInterface
      */
     protected function driverReadAllKeys(string $pattern = '*'): iterable
     {
-        $keys = [[]];
+        $result = [[]];
         foreach ($this->instance->_masters() as $master) {
-            $i = -1;
-            $result = $this->instance->scan(
-                $i,
-                $master,
-                $pattern === '' ? '*' : $pattern,
-                ExtendedCacheItemPoolInterface::MAX_ALL_KEYS_COUNT
-            );
-            if (is_array($result)) {
-                $keys[] = $result;
-            }
+            $i = null;
+            $pattern = $pattern === '' ? '*' : $pattern;
+            do {
+                $result[] = $this->instance->scan(
+                    $i,
+                    $master,
+                    $pattern,
+                    10);
+                if (\count($result) > ExtendedCacheItemPoolInterface::MAX_ALL_KEYS_COUNT) {
+                    break;
+                }
+            } while ($i > 0);
         }
-
-        return array_unique(array_merge(...$keys));
+        return array_unique(\array_merge(...$result));
     }
 
     /**


### PR DESCRIPTION
The Redis driver's function to read all keys has been streamlined. The change is adding a loop to scan and merge the keys iteratively. This ensures that the function will work correctly, even when the number of keys scanned exceeds the MAX_ALL_KEYS_COUNT.

## Proposed changes

This is a fix for https://github.com/PHPSocialNetwork/phpfastcache/issues/912

## Types of changes

What types of changes does your code introduce to Phpfastcache?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves an existing code/behavior)
- [ ] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs


