### PR TITLE
adjust rediscluster constant options

### DIFF
--- a/lib/Phpfastcache/Drivers/Rediscluster/Driver.php
+++ b/lib/Phpfastcache/Drivers/Rediscluster/Driver.php
@@ -24,6 +24,7 @@ use Phpfastcache\Drivers\Redis\RedisDriverTrait;
 use Phpfastcache\Entities\DriverStatistic;
 use Phpfastcache\Exceptions\PhpfastcacheLogicException;
 use RedisCluster;
+use Redis;
 
 /**
  * @property RedisCluster $instance
@@ -104,10 +105,10 @@ class Driver implements AggregatablePoolInterface
             $this->getConfig()->getPassword()
         );
 
-        $this->instance->setOption(RedisCluster::OPT_SCAN, RedisCluster::SCAN_RETRY);
+        $this->instance->setOption(Redis::OPT_SCAN, Redis::SCAN_RETRY);
 
         if ($this->getConfig()->getOptPrefix()) {
-            $this->instance->setOption(RedisCluster::OPT_PREFIX, $this->getConfig()->getOptPrefix());
+            $this->instance->setOption(Redis::OPT_PREFIX, $this->getConfig()->getOptPrefix());
         }
 
         if ($this->getConfig()->getSlaveFailover()) {


### PR DESCRIPTION
## Proposed changes

update constants which we're using for the RedisCluster option were removed: https://github.com/phpredis/phpredis/issues/2262

## Types of changes

What types of changes does your code introduce to Phpfastcache?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves an existing code/behavior)
- [x] Deprecated third party dependency update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation/Typo/Resource update that does not involve any code modification

## Agreement

I have read the [CONTRIBUTING](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CONTRIBUTING.md) and [CODING GUIDELINE](https://github.com/PHPSocialNetwork/phpfastcache/blob/master/CODING_GUIDELINE.md) docs

## Further comments

N/A
